### PR TITLE
(INF): Fix RustFileType

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -30,7 +30,7 @@
 
         <fileTypeFactory implementation="org.rust.lang.RustFileTypeFactory"/>
 
-        <lang.syntaxHighlighterFactory key="RUST" implementationClass="org.rust.lang.RustHighlighter.Factory"/>
+        <lang.syntaxHighlighterFactory key="RUST" implementationClass="org.rust.lang.RustHighlighterFactory"/>
 
         <lang.parserDefinition language="RUST" implementationClass="org.rust.lang.core.RustParserDefinition"/>
 

--- a/src/org/rust/lang/RustFileType.kt
+++ b/src/org/rust/lang/RustFileType.kt
@@ -1,9 +1,7 @@
 package org.rust.lang
 
-import com.intellij.icons.AllIcons
-import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
-import org.jetbrains
+import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
 public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
@@ -11,12 +9,12 @@ public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
     public object INSTANCE : RustFileType() {}
 
     public object DEFAULTS {
-        public val EXTENSION: String = "rust";
+        public val EXTENSION: String = "rs";
     }
 
     override fun getName(): String = "Rust"
 
-    override fun getIcon(): Icon? = AllIcons.FileTypes.Java;
+    override fun getIcon(): Icon = RustIcons.NORMAL;
 
     override fun getDefaultExtension(): String = DEFAULTS.EXTENSION
 

--- a/src/org/rust/lang/RustFileTypeFactory.kt
+++ b/src/org/rust/lang/RustFileTypeFactory.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.fileTypes.FileTypeFactory
 public class RustFileTypeFactory : FileTypeFactory() {
 
     override fun createFileTypes(consumer: FileTypeConsumer) {
-        consumer.consume(RustFileType.INSTANCE, "rust");
+        consumer.consume(RustFileType.INSTANCE, RustFileType.DEFAULTS.EXTENSION);
     }
 
 }

--- a/src/org/rust/lang/RustHighlighter.kt
+++ b/src/org/rust/lang/RustHighlighter.kt
@@ -16,10 +16,6 @@ import org.rust.lang.core.lexer.RustTokenElementTypes.*
 
 public class RustHighlighter : SyntaxHighlighterBase() {
 
-    public class Factory : SyntaxHighlighterFactory() {
-        override fun getSyntaxHighlighter(project: Project?, virtualFile: VirtualFile?) = RustHighlighter();
-    }
-
     object Colors {
 
         fun r(id: String, attrKey: TextAttributesKey) =

--- a/src/org/rust/lang/RustHighlighterFactory.kt
+++ b/src/org/rust/lang/RustHighlighterFactory.kt
@@ -1,0 +1,14 @@
+package org.rust.lang
+
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+
+/**
+ * @author Aleksey.Kladov
+ */
+public class RustHighlighterFactory : SyntaxHighlighterFactory() {
+    override fun getSyntaxHighlighter(project: Project?, virtualFile: VirtualFile?) = RustHighlighter();
+}
+

--- a/src/org/rust/lang/RustLanguage.kt
+++ b/src/org/rust/lang/RustLanguage.kt
@@ -1,22 +1,9 @@
 package org.rust.lang
 
 import com.intellij.lang.Language
-import com.intellij.openapi.fileTypes.SyntaxHighlighter
-import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
 
-public open class RustLanguage : Language {
+public open class RustLanguage : Language("RUST") {
 
     object INSTANCE : RustLanguage() {}
-
-    constructor() : super("RUST") {
-        SyntaxHighlighterFactory.LANGUAGE_FACTORY.addExplicitExtension(this, object: SyntaxHighlighterFactory() {
-            override fun getSyntaxHighlighter(project: Project?, virtualFile: VirtualFile?): SyntaxHighlighter {
-                return RustHighlighter();
-            }
-        })
-    }
-
 }
 


### PR DESCRIPTION
* set default extension for rust to ".rs'"
* use proper icon for files
* extract RustHighlighterFactory to a separate file

The last change is a workaround:class not found exception was thrown when Factory was inside RustHighlighter

@alexeykudinkin am I correct that (INF) is infrastructure?