### PR TITLE
Basic support for file structure

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -34,9 +34,13 @@
 
         <lang.parserDefinition language="RUST" implementationClass="org.rust.lang.core.RustParserDefinition"/>
 
+        <lang.psiStructureViewFactory language="RUST"
+                                      implementationClass="org.rust.lang.structure.RustPsiStructureViewFactory"/>
+
         <annotator language="RUST" implementationClass="org.rust.lang.annotator.RustAnnotator"/>
 
         <fileTypeFactory implementation="org.toml.lang.TomlFileTypeFactory"/>
+
 
         <lang.syntaxHighlighterFactory key="TOML" implementationClass="org.toml.lang.TomlHighlighterFactory"/>
 

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -39,8 +39,10 @@
 
         <annotator language="RUST" implementationClass="org.rust.lang.annotator.RustAnnotator"/>
 
-        <fileTypeFactory implementation="org.toml.lang.TomlFileTypeFactory"/>
+        <iconProvider implementation="org.rust.lang.icons.RustIconProvider"/>
 
+
+        <fileTypeFactory implementation="org.toml.lang.TomlFileTypeFactory"/>
 
         <lang.syntaxHighlighterFactory key="TOML" implementationClass="org.toml.lang.TomlHighlighterFactory"/>
 

--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -129,12 +129,13 @@
     implements  ("pat_ident") = "org.rust.lang.core.psi.RustNamedElement"
 
     implements  ("fn_item") = "org.rust.lang.core.resolve.scope.RustResolveScope"
-    mixin       ("fn_item") = "org.rust.lang.core.psi.impl.mixin.RustFnItemImplMixin"
+//    mixin       ("fn_item") = "org.rust.lang.core.psi.impl.mixin.RustFnItemImplMixin"
 
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr
 
-    extends(".*_item") = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
+    extends("impl_method") = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
+    extends(".*_item")     = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
 
     extends(".*_expr") = expr
     extends(".*_stmt") = stmt

--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -129,7 +129,7 @@
     implements  ("pat_ident") = "org.rust.lang.core.psi.RustNamedElement"
 
     implements  ("fn_item") = "org.rust.lang.core.resolve.scope.RustResolveScope"
-//    mixin       ("fn_item") = "org.rust.lang.core.psi.impl.mixin.RustFnItemImplMixin"
+    mixin       ("fn_item") = "org.rust.lang.core.psi.impl.mixin.RustFnItemImplMixin"
 
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr

--- a/src/org/rust/lang/core/psi/impl/mixin/RustFnItemImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustFnItemImplMixin.kt
@@ -2,12 +2,11 @@ package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustFnItem
-import org.rust.lang.core.psi.impl.RustCompositeElementImpl
 import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.resolve.scope.RustResolveScope
 
 public abstract class RustFnItemImplMixin(node: ASTNode)
-    : RustCompositeElementImpl(node)
+    : RustNamedElementImpl(node)
     , RustFnItem
     , RustResolveScope {
 

--- a/src/org/rust/lang/core/psi/impl/mixin/RustFnItemImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustFnItemImplMixin.kt
@@ -3,6 +3,7 @@ package org.rust.lang.core.psi.impl.mixin
 import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustFnItem
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
+import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.resolve.scope.RustResolveScope
 
 public abstract class RustFnItemImplMixin(node: ASTNode)

--- a/src/org/rust/lang/icons/RustIconProvider.kt
+++ b/src/org/rust/lang/icons/RustIconProvider.kt
@@ -1,0 +1,17 @@
+package org.rust.lang.icons
+
+import com.intellij.ide.IconProvider
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.impl.RustFnItemImpl
+import org.rust.lang.core.psi.impl.RustImplMethodImpl
+import javax.swing.Icon
+
+class RustIconProvider: IconProvider() {
+    override fun getIcon(element: PsiElement, flags: Int): Icon? {
+        return when (element) {
+            is RustFnItemImpl -> RustIcons.FUNCTION
+            is RustImplMethodImpl -> RustIcons.METHOD
+            else -> null
+        }
+    }
+}

--- a/src/org/rust/lang/icons/RustIcons.kt
+++ b/src/org/rust/lang/icons/RustIcons.kt
@@ -1,5 +1,6 @@
 package org.rust.lang.icons
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.IconLoader
 import javax.swing.Icon
 
@@ -11,4 +12,6 @@ public object RustIcons {
     public val NORMAL:  Icon = IconLoader.getIcon("/org/rust/icons/rust16.png")
     public val BIG:     Icon = IconLoader.getIcon("/org/rust/icons/rust32.png")
 
+    public val FUNCTION = AllIcons.Nodes.Function
+    public val METHOD   = AllIcons.Nodes.Method
 }

--- a/src/org/rust/lang/structure/RustPsiStructureViewFactory.kt
+++ b/src/org/rust/lang/structure/RustPsiStructureViewFactory.kt
@@ -1,0 +1,20 @@
+package org.rust.lang.structure
+
+import com.intellij.ide.structureView.StructureViewBuilder
+import com.intellij.ide.structureView.StructureViewModel
+import com.intellij.ide.structureView.TreeBasedStructureViewBuilder
+import com.intellij.lang.PsiStructureViewFactory
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.impl.RustFileImpl
+
+public class RustPsiStructureViewFactory: PsiStructureViewFactory {
+    override fun getStructureViewBuilder(psiFile: PsiFile?): StructureViewBuilder {
+        val rustFile = psiFile as RustFileImpl;
+        return object: TreeBasedStructureViewBuilder() {
+            override fun createStructureViewModel(editor: Editor?): StructureViewModel {
+                return RustStructureViewModel(editor, rustFile)
+            }
+        }
+    }
+}

--- a/src/org/rust/lang/structure/RustStructureViewElement.kt
+++ b/src/org/rust/lang/structure/RustStructureViewElement.kt
@@ -34,8 +34,7 @@ class RustStructureViewElement(val element: RustNamedElementImpl) : StructureVie
     }
 
     override fun getValue(): Any? {
-        return this
-
+        return element
     }
 
 }

--- a/src/org/rust/lang/structure/RustStructureViewElement.kt
+++ b/src/org/rust/lang/structure/RustStructureViewElement.kt
@@ -1,0 +1,41 @@
+package org.rust.lang.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.navigation.ItemPresentation
+import org.rust.lang.core.psi.impl.RustNamedElementImpl
+import javax.swing.Icon
+
+class RustStructureViewElement(val element: RustNamedElementImpl) : StructureViewTreeElement {
+    override fun getPresentation(): ItemPresentation {
+        return object : ItemPresentation {
+            override fun getLocationString(): String? = null
+
+            override fun getIcon(unused: Boolean): Icon? = element.getIcon(0)
+
+            override fun getPresentableText(): String? = element.name
+        }
+    }
+
+    override fun getChildren(): Array<out TreeElement> {
+        return arrayOf();
+    }
+
+    override fun canNavigate(): Boolean {
+        return true
+    }
+
+    override fun canNavigateToSource(): Boolean {
+        return true
+    }
+
+    override fun navigate(requestFocus: Boolean) {
+        element.navigate(requestFocus)
+    }
+
+    override fun getValue(): Any? {
+        return this
+
+    }
+
+}

--- a/src/org/rust/lang/structure/RustStructureViewModel.kt
+++ b/src/org/rust/lang/structure/RustStructureViewModel.kt
@@ -1,0 +1,16 @@
+package org.rust.lang.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.structureView.TextEditorBasedStructureViewModel
+import com.intellij.openapi.editor.Editor
+import org.rust.lang.core.psi.impl.RustFileImpl
+
+class RustStructureViewModel(editor: Editor?, val file: RustFileImpl) :
+        TextEditorBasedStructureViewModel(editor, file) {
+
+    override fun getRoot(): StructureViewTreeElement {
+        return RustStructureViewTreeElement(file)
+    }
+}
+
+

--- a/src/org/rust/lang/structure/RustStructureViewTreeElement.kt
+++ b/src/org/rust/lang/structure/RustStructureViewTreeElement.kt
@@ -1,0 +1,31 @@
+package org.rust.lang.structure
+
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.impl.RustFileImpl
+import org.rust.lang.core.psi.impl.RustFnItemImpl
+import org.rust.lang.core.psi.impl.RustImplMethodImpl
+
+class RustStructureViewTreeElement(file: RustFileImpl) : PsiTreeElementBase<RustFileImpl>(file) {
+    override fun getPresentableText(): String? = element?.name
+
+
+    override fun getChildrenBase(): Collection<RustStructureViewElement> {
+        var result = listOf<RustStructureViewElement>()
+        element?.accept(object :
+                PsiElementVisitor() {
+            override fun visitElement(element: PsiElement?) {
+                when (element) {
+                    is RustFnItemImpl ->
+                        result += RustStructureViewElement(element)
+                    is RustImplMethodImpl ->
+                        result += RustStructureViewElement(element)
+                }
+                element?.children?.forEach { it.accept(this) }
+            }
+        })
+
+        return result;
+    }
+}


### PR DESCRIPTION
This adds basic file structure.

The structure is flat and consists of a list of functions and methods, found in the file. It can be enhanced greatly, but even in current the state it helps navigating large files, like `libsyntax/parser/parser.rs` tremendously.  

IconProvider for PSI nodes is added as a side effect. 


I plan to add smoke test for the structure in the next PR. 