### PR TITLE
(T): smoke test for StructureView

### DIFF
--- a/test/org/rust/lang/RustStructureViewTest.kt
+++ b/test/org/rust/lang/RustStructureViewTest.kt
@@ -1,0 +1,43 @@
+package org.rust.lang
+
+import com.intellij.ide.actions.ViewStructureAction
+import com.intellij.ide.util.FileStructurePopup
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
+import com.intellij.openapi.util.Disposer
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import org.hamcrest.CoreMatchers
+import org.junit.Assert
+import javax.swing.tree.TreePath
+
+class RustStructureViewTest : LightCodeInsightFixtureTestCase() {
+    override fun getTestDataPath() = "testData/structure"
+
+    private fun structureContainsElements(vararg expected: String) {
+        val fileName = getTestName(true) + ".rs"
+        myFixture.configureByFile(fileName)
+        val editor = TextEditorProvider.getInstance()!!.getTextEditor(myFixture.editor)
+        val popup = ViewStructureAction.createPopup(myFixture.project, editor)
+                ?: throw AssertionError("popup mustn't be null")
+
+        try {
+            popup.createCenterPanel()
+            popup.shallowExpand()
+            val text = PlatformTestUtil.print(popup.tree)
+
+            expected.forEach {
+                Assert.assertThat(text, CoreMatchers.containsString(it))
+            }
+        } finally {
+            Disposer.dispose(popup)
+        }
+    }
+
+    private fun FileStructurePopup.shallowExpand() {
+        tree.expandPath(TreePath(tree.model.root))
+    }
+
+    fun testFunctions() {
+        structureContainsElements("fn_foo", "method_bar")
+    }
+}

--- a/testData/structure/functions.rs
+++ b/testData/structure/functions.rs
@@ -1,0 +1,9 @@
+fn fn_foo () {
+
+}
+
+struct S;
+
+impl S {
+    fn method_bar(&self) { }
+}


### PR DESCRIPTION
Matching is simplistic at the moment: the top level of the structure
view is expanded, the resulting "tree" is dumped to a string and the
names of expected entries are searched for. This should work fine while
we have a flat structure. This should also be resilient to adding more kinds of structure elements.

@Atsky please, review. I'm particularly not sure about `Disposer.dispose` thing, because Kotlin's version does not have one. But if I omit disposing, I get warnings about leaks in console. 