### PR TITLE
Resolve match

### DIFF
--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -136,6 +136,9 @@
     implements  ("block") =  "org.rust.lang.core.resolve.scope.RustResolveScope"
     mixin       ("block") =  "org.rust.lang.core.psi.impl.mixin.RustBlockImplMixin"
 
+    implements  ("match_arm") = "org.rust.lang.core.resolve.scope.RustResolveScope"
+    mixin       ("match_arm") = "org.rust.lang.core.psi.impl.mixin.RustMatchArmImplMixin"
+
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr
 
@@ -791,7 +794,7 @@ for_expr ::= [lifetime COLON] FOR pat IN no_struct_lit_expr block { pin = "IN" }
 
 match_expr ::= MATCH no_struct_lit_expr LBRACE match_arm* RBRACE
 
-private match_arm ::= outer_attrs* match_pat FAT_ARROW (expr (COMMA | & RBRACE) | block )
+match_arm ::= outer_attrs* match_pat FAT_ARROW (expr (COMMA | & RBRACE) | block )
 private match_pat ::= pat (OR pat)* (IF expr)?
 
 if_expr ::= IF no_struct_lit_expr block else_tail?

--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -139,12 +139,16 @@
     implements  ("match_arm") = "org.rust.lang.core.resolve.scope.RustResolveScope"
     mixin       ("match_arm") = "org.rust.lang.core.psi.impl.mixin.RustMatchArmImplMixin"
 
+    implements  ("cond_let_expr") = "org.rust.lang.core.resolve.scope.RustResolveScope"
+    mixin       ("cond_let_expr") = "org.rust.lang.core.psi.impl.mixin.RustCondLetExprImplMixin"
+
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr
 
     extends("impl_method") = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
     extends(".*_item")     = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
 
+    extends("(if|while)_let_expr") = cond_let_expr
     extends(".*_expr") = restricted_expr
     extends(".*_stmt") = stmt
     extends("pat_.*")  = pat
@@ -800,6 +804,8 @@ private match_pat ::= pat (OR pat)* (IF expr)?
 if_expr ::= IF no_struct_lit_expr block else_tail?
 
 private else_tail ::= ELSE (if_expr | if_let_expr | block )
+
+fake cond_let_expr ::= pat
 
 if_let_expr ::= IF LET pat EQ no_struct_lit_expr block  else_tail?
 

--- a/src/org/rust/lang/core/psi/impl/mixin/RustCondLetExprImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustCondLetExprImplMixin.kt
@@ -1,0 +1,14 @@
+package org.rust.lang.core.psi.impl.mixin
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustCondLetExpr
+import org.rust.lang.core.psi.RustPatIdent
+import org.rust.lang.core.psi.impl.RustCompositeElementImpl
+import org.rust.lang.core.psi.util.boundIdentifiers
+
+abstract class RustCondLetExprImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
+        , RustCondLetExpr {
+
+    override fun listDeclarations(before: PsiElement): List<RustPatIdent> = pat.boundIdentifiers
+}

--- a/src/org/rust/lang/core/psi/impl/mixin/RustMatchArmImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustMatchArmImplMixin.kt
@@ -1,0 +1,17 @@
+package org.rust.lang.core.psi.impl.mixin
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustMatchArm
+import org.rust.lang.core.psi.RustPatIdent
+import org.rust.lang.core.psi.impl.RustCompositeElementImpl
+import org.rust.lang.core.psi.util.boundIdentifiers
+import org.rust.lang.core.resolve.scope.RustResolveScope
+
+abstract class RustMatchArmImplMixin(node: ASTNode): RustCompositeElementImpl(node)
+        , RustMatchArm
+        , RustResolveScope {
+
+    override fun listDeclarations(before: PsiElement): List<RustPatIdent> = patList
+            .flatMap {it.boundIdentifiers}
+}

--- a/src/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -1,6 +1,7 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustCondLetExpr
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustVisitor
 import org.rust.lang.core.psi.util.match
@@ -56,6 +57,10 @@ public class RustResolveEngine(ref: RustQualifiedReference) {
 
                 return s
             }
+        }
+
+        override fun visitCondLetExpr(o: RustCondLetExpr) {
+            visitResolveScope(o)
         }
 
         override fun visitResolveScope(elem: RustResolveScope) {

--- a/src/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -1,7 +1,8 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustVisitor
 import org.rust.lang.core.psi.util.match
 import org.rust.lang.core.resolve.ref.RustQualifiedReference
 import org.rust.lang.core.resolve.scope.RustResolveScope
@@ -57,15 +58,7 @@ public class RustResolveEngine(ref: RustQualifiedReference) {
             }
         }
 
-        override fun visitBlock(block: RustBlock) {
-            visitDeclarationSet(block)
-        }
-
-        override fun visitFnItem(fn: RustFnItem) {
-            visitDeclarationSet(fn)
-        }
-
-        private fun visitDeclarationSet(elem: RustResolveScope) {
+        override fun visitResolveScope(elem: RustResolveScope) {
             elem.listDeclarations(ref)
                     .forEach { ident ->
                         if (match(ident)) {

--- a/test/org/rust/lang/core/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/RustResolveTestCase.kt
@@ -14,6 +14,7 @@ class RustResolveTestCase : RustTestCase() {
     fun testLocals()               { checkIsBound()   }
     fun testShadowing()            { checkIsBound(atOffset = 35) }
     fun testNested()               { checkIsBound()   }
+    fun testMatch()                { checkIsBound()   }
     fun testUnbound()              { checkIsUnbound() }
     fun testOrdering()             { checkIsUnbound() }
     //@formatter:on

--- a/test/org/rust/lang/core/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/RustResolveTestCase.kt
@@ -15,6 +15,8 @@ class RustResolveTestCase : RustTestCase() {
     fun testShadowing()            { checkIsBound(atOffset = 35) }
     fun testNested()               { checkIsBound()   }
     fun testMatch()                { checkIsBound()   }
+    fun testIflet()                { checkIsBound()   }
+    fun testWhilelet()             { checkIsBound()   }
     fun testUnbound()              { checkIsUnbound() }
     fun testOrdering()             { checkIsUnbound() }
     //@formatter:on

--- a/testData/resolve/iflet.rs
+++ b/testData/resolve/iflet.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if let Some(i) =  Some(92) {
+        <caret>i;
+    }
+}

--- a/testData/resolve/match.rs
+++ b/testData/resolve/match.rs
@@ -1,0 +1,6 @@
+fn main() {
+    match Some(92) {
+        Some(i) => { <caret>i }
+        _ => 0
+    };
+}

--- a/testData/resolve/whilelet.rs
+++ b/testData/resolve/whilelet.rs
@@ -1,0 +1,5 @@
+fn main() {
+    while let Some(i) = Some(92) {
+        <caret>i;
+    }
+}


### PR DESCRIPTION
@Atsky please review.

I hate the explicit forwarding of `visitCondLet` to `visitResolveScope`, but generate `RustVisitor` has the following code

```java
  public void visitCondLetExpr(@NotNull RustCondLetExpr o) {
    visitRestrictedExpr(o);
    // visitResolveScope(o);
  }
```

It is understandable (neither of `RestrictedExpr` and `ResolveScope` is a subset of the other), but it still feels ugly. 