### PR TITLE
Implement resolve in for loops

### DIFF
--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -145,8 +145,8 @@
     implements  ("match_arm") = "org.rust.lang.core.resolve.scope.RustResolveScope"
     mixin       ("match_arm") = "org.rust.lang.core.psi.impl.mixin.RustMatchArmImplMixin"
 
-    implements  ("cond_let_expr") = "org.rust.lang.core.resolve.scope.RustResolveScope"
-    mixin       ("cond_let_expr") = "org.rust.lang.core.psi.impl.mixin.RustCondLetExprImplMixin"
+    implements  ("scoped_let_expr") = "org.rust.lang.core.resolve.scope.RustResolveScope"
+    mixin       ("scoped_let_expr") = "org.rust.lang.core.psi.impl.mixin.RustScopedLetExprImplMixin"
 
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr
@@ -154,7 +154,7 @@
     extends("impl_method") = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
     extends(".*_item")     = "org.rust.lang.core.psi.impl.RustNamedElementImpl"
 
-    extends("(if|while)_let_expr") = cond_let_expr
+    extends("((if|while)_let|for)_expr") = scoped_let_expr
     extends(".*_expr") = restricted_expr
     extends(".*_stmt") = stmt
     extends("pat_.*")  = pat
@@ -814,7 +814,7 @@ if_expr ::= IF no_struct_lit_expr block else_tail?
 
 private else_tail ::= ELSE (if_expr | if_let_expr | block )
 
-fake cond_let_expr ::= pat
+fake scoped_let_expr ::= pat
 
 if_let_expr ::= IF LET pat EQ no_struct_lit_expr block  else_tail?
 

--- a/src/org/rust/lang/core/psi/impl/mixin/RustScopedLetExprImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustScopedLetExprImplMixin.kt
@@ -2,13 +2,13 @@ package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RustCondLetExpr
 import org.rust.lang.core.psi.RustPatVar
+import org.rust.lang.core.psi.RustScopedLetExpr
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
 import org.rust.lang.core.psi.util.boundVariables
 
-abstract class RustCondLetExprImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
-        , RustCondLetExpr {
+abstract class RustScopedLetExprImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
+        , RustScopedLetExpr {
 
     override fun listDeclarations(before: PsiElement): List<RustPatVar> = pat.boundVariables
 }

--- a/src/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -1,7 +1,7 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RustCondLetExpr
+import org.rust.lang.core.psi.RustScopedLetExpr
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustVisitor
 import org.rust.lang.core.psi.util.match
@@ -59,7 +59,7 @@ public class RustResolveEngine(ref: RustQualifiedValue) {
             }
         }
 
-        override fun visitCondLetExpr(o: RustCondLetExpr) {
+        override fun visitScopedLetExpr(o: RustScopedLetExpr) {
             visitResolveScope(o)
         }
 

--- a/test/org/rust/lang/core/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/RustResolveTestCase.kt
@@ -17,6 +17,7 @@ class RustResolveTestCase : RustTestCase() {
     fun testMatch()                { checkIsBound()   }
     fun testIfLet()                { checkIsBound()   }
     fun testWhileLet()             { checkIsBound()   }
+    fun testFor()                  { checkIsBound()   }
     fun testTraitMethodArgument()  { checkIsBound()   }
     fun testImplMethodArgument()   { checkIsBound()   }
     fun testStructPatterns1()      { checkIsBound(atOffset = 69) }

--- a/testData/resolve/for.rs
+++ b/testData/resolve/for.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for x in 0..10 {
+        <caret>x;
+    }
+}


### PR DESCRIPTION
The implementation is merged together with if/while let expressions. I renamed `RustCondLetExpr` to `RustScopedLetExpr` because a for loop is a kind of let (binding) expression, but not a conditional one.