### PR TITLE
Basic support for cargo projects

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,6 +49,19 @@
         <lang.syntaxHighlighterFactory language="TOML" implementationClass="org.toml.lang.TomlHighlighterFactory"/>
 
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.core.parser.TomlParserDefinition"/>
+
+        <applicationService serviceImplementation="org.rust.lang.config.RustConfigService" />
+        <applicationConfigurable instance="org.rust.lang.config.RustConfigEntry" />
+
+        <!-- Cargo -->
+        <externalSystemManager implementation="org.rust.cargo.project.CargoExternalSystemManager"/>
+
+        <projectService serviceImplementation="org.rust.cargo.project.settings.CargoSettings"/>
+        <projectService serviceImplementation="org.rust.cargo.project.settings.CargoLocalSettings"/>
+        <projectService serviceImplementation="org.rust.cargo.project.settings.CargoProjectSettings"/>
+
+        <projectImportProvider implementation="org.rust.cargo.project.CargoProjectImportProvider"/>
+        <projectImportBuilder implementation="org.rust.cargo.project.CargoProjectImportBuilder"/>
     </extensions>
 
     <application-components>

--- a/resources/org/rust/lang/i18n/RustBundle.properties
+++ b/resources/org/rust/lang/i18n/RustBundle.properties
@@ -1,0 +1,48 @@
+file.type.name.rust=Rust Source
+file.type.description.rust=Rust language source code
+
+language.name.rust=Rust
+sdk.name.rust=Rust SDK
+sdk.fullname.rust=Rust {0}
+
+rust.module.type.name=Rust Module
+rust.module.type.description=A module supporting Rust development
+
+file.name.rust=Rust File
+
+action.create.rust.file=Rust File
+action.create.rust.file.description=Create new Rust file
+prompt.enter.new.rust.file.name=Enter a new Rust file name
+title.new.rust.file=New Rust File
+
+annotator.warning.bounds=By default it is assumed that the value ascribes to no trait bounds
+
+options.rust.attribute.descriptor.keyword = Keyword
+options.rust.attribute.descriptor.identifier = Identifier
+options.rust.attribute.descriptor.block_comment = Block comment
+options.rust.attribute.descriptor.line_comment = Line comment
+options.rust.attribute.descriptor.doc_comment = Doc comment
+options.rust.attribute.descriptor.string = String
+options.rust.attribute.descriptor.number = Number
+options.rust.attribute.descriptor.brackets = Brackets
+options.rust.attribute.descriptor.braces = Braces
+options.rust.attribute.descriptor.parentheses = Parentheses
+options.rust.attribute.descriptor.comma = Comma
+options.rust.attribute.descriptor.symbol = Symbol
+options.rust.attribute.descriptor.semicolon = Semicolon
+options.rust.attribute.descriptor.operator = Operator
+options.rust.attribute.descriptor.path_separator = Path separator
+options.rust.attribute.descriptor.attribute = Attribute
+options.rust.attribute.descriptor.delimiter = Delimiter
+options.rust.attribute.descriptor.bad_char = Bad character
+
+runner.cargo.name=Cargo
+runner.cargo.description=Runs Rust crates with Cargo
+runner.cargo.target.build=build
+runner.cargo.target.run=run
+runner.cargo.label.workdir=Working Directory\:
+runner.cargo.label.target=Target\:
+
+config.name=Rust
+config.help-topic=Rust and Cargo configuration
+config.label.cargo-binary=Cargo Binary\:

--- a/src/org/rust/cargo/Cargo.kt
+++ b/src/org/rust/cargo/Cargo.kt
@@ -1,0 +1,11 @@
+package org.rust.cargo
+
+import com.intellij.openapi.util.IconLoader
+
+object Cargo {
+    val ID = "Cargo"
+    val NAME = "Cargo"
+    val BUILD_FILE = "Cargo.toml"
+    val LOCK_FILE = "Cargo.lock"
+    val ICON = IconLoader.getIcon("/org/toml/icons/cargo16.png")
+}

--- a/src/org/rust/cargo/project/CargoAutoImport.kt
+++ b/src/org/rust/cargo/project/CargoAutoImport.kt
@@ -1,0 +1,20 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.ExternalSystemAutoImportAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtilCore
+import org.rust.cargo.Cargo
+
+import java.io.File
+
+class CargoAutoImport : ExternalSystemAutoImportAware {
+    override fun getAffectedExternalProjectPath(changedFileOrDirPath: String, project: Project): String? {
+        val changed = File(changedFileOrDirPath)
+        val name = changed.name
+        val base = File(project.basePath)
+        if ((Cargo.BUILD_FILE == name || Cargo.LOCK_FILE == name) && VfsUtilCore.isAncestor(base, changed, true)) {
+            return project.basePath
+        }
+        return null
+    }
+}

--- a/src/org/rust/cargo/project/CargoExternalSystemManager.kt
+++ b/src/org/rust/cargo/project/CargoExternalSystemManager.kt
@@ -1,0 +1,93 @@
+package org.rust.cargo.project
+
+import com.google.gson.Gson
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.SimpleJavaParameters
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.externalSystem.ExternalSystemAutoImportAware
+import com.intellij.openapi.externalSystem.ExternalSystemManager
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.service.project.ExternalSystemProjectResolver
+import com.intellij.openapi.externalSystem.service.project.autoimport.CachingExternalSystemAutoImportAware
+import com.intellij.openapi.externalSystem.task.ExternalSystemTaskManager
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.util.Function
+import com.intellij.util.PathUtil
+import org.apache.commons.lang.StringUtils
+import org.rust.cargo.project.settings.*
+import org.rust.lang.config.RustConfigService
+
+import java.net.URL
+
+class CargoExternalSystemManager : ExternalSystemAutoImportAware,
+        ExternalSystemManager<CargoProjectSettings, CargoProjectSettingsListener, CargoSettings,
+                CargoLocalSettings, CargoExecutionSettings> {
+
+    override fun getSystemId(): ProjectSystemId {
+        return CargoProjectSystem.ID
+    }
+
+    override fun getSettingsProvider(): Function<Project, CargoSettings> {
+        return object : Function<Project, CargoSettings> {
+            override fun `fun`(project: Project): CargoSettings {
+                return CargoSettings.getInstance(project)
+            }
+        }
+    }
+
+    override fun getLocalSettingsProvider(): Function<Project, CargoLocalSettings> {
+        return object : Function<Project, CargoLocalSettings> {
+            override fun `fun`(project: Project): CargoLocalSettings {
+                return CargoLocalSettings.getInstance(project)
+            }
+        }
+    }
+
+    override fun getExecutionSettingsProvider(): Function<Pair<Project, String>, CargoExecutionSettings> {
+        return object : Function<Pair<Project, String>, CargoExecutionSettings> {
+            override fun `fun`(pair: Pair<Project, String>): CargoExecutionSettings {
+                return executionSettingsFor(pair.getFirst(), pair.getSecond())
+            }
+        }
+    }
+
+    override fun getProjectResolverClass(): Class<out ExternalSystemProjectResolver<CargoExecutionSettings>> {
+        return CargoProjectResolver::class.java
+    }
+
+    override fun getTaskManagerClass(): Class<out ExternalSystemTaskManager<CargoExecutionSettings>> {
+        return CargoTaskManager::class.java
+    }
+
+    override fun getExternalProjectDescriptor(): FileChooserDescriptor {
+        return CargoOpenProjectDescriptor()
+    }
+
+    private val delegate = CachingExternalSystemAutoImportAware(CargoAutoImport())
+
+    override fun getAffectedExternalProjectPath(changedFileOrDirPath: String, project: Project): String? {
+        return delegate.getAffectedExternalProjectPath(changedFileOrDirPath, project)
+    }
+
+    @Throws(ExecutionException::class)
+    override fun enhanceRemoteProcessing(parameters: SimpleJavaParameters) {
+        parameters.classPath.add(PathUtil.getJarPathForClass(StringUtils::class.java))
+        parameters.classPath.add(PathUtil.getJarPathForClass(Gson::class.java))
+        parameters.classPath.add(PathUtil.getJarPathForClass(TypeCastException::class.java))
+        parameters.classPath.add(PathUtil.getJarPathForClass(kotlin.Charsets::class.java))
+        //parameters.getVMParametersList().add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+    }
+
+    override fun enhanceLocalProcessing(urls: List<URL>) {
+    }
+
+    companion object {
+        internal fun executionSettingsFor(project: Project, path: String): CargoExecutionSettings {
+            return CargoExecutionSettings(
+                    ServiceManager.getService(RustConfigService::class.java).state.cargoBinary,
+                    ServiceManager.getService(project, CargoProjectSettings::class.java).features)
+        }
+    }
+}

--- a/src/org/rust/cargo/project/CargoImportControl.kt
+++ b/src/org/rust/cargo/project/CargoImportControl.kt
@@ -1,0 +1,72 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.service.settings.AbstractExternalProjectSettingsControl
+import com.intellij.openapi.externalSystem.service.settings.AbstractImportFromExternalSystemControl
+import com.intellij.openapi.externalSystem.util.ExternalSystemSettingsControl
+import com.intellij.openapi.externalSystem.util.PaintAwarePanel
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.project.ProjectManager
+import org.rust.cargo.project.settings.CargoProjectSettings
+import org.rust.cargo.project.settings.CargoProjectSettingsListener
+import org.rust.cargo.project.settings.CargoSettings
+
+class CargoImportControl :
+        AbstractImportFromExternalSystemControl<CargoProjectSettings,CargoProjectSettingsListener, CargoSettings>(
+                CargoProjectSystem.ID, CargoSettings(ProjectManager.getInstance().defaultProject),
+                CargoProjectSettings()) {
+
+    override fun onLinkedProjectPathChange(s: String) {
+    }
+
+    override fun createProjectSettingsControl(
+            settings: CargoProjectSettings): ExternalSystemSettingsControl<CargoProjectSettings> {
+        return object : AbstractExternalProjectSettingsControl<CargoProjectSettings>(settings) {
+            override fun fillExtraControls(paintAwarePanel: PaintAwarePanel, identLevel: Int) {
+            }
+
+            override fun isExtraSettingModified(): Boolean {
+                return false
+            }
+
+            override fun resetExtraSettings(b: Boolean) {
+            }
+
+            override fun applyExtraSettings(settings: CargoProjectSettings) {
+
+            }
+
+            @Throws(ConfigurationException::class)
+            override fun validate(settings: CargoProjectSettings): Boolean {
+                return true
+            }
+        }
+    }
+
+    override fun createSystemSettingsControl(systemSettings: CargoSettings): ExternalSystemSettingsControl<CargoSettings>? {
+        return object : ExternalSystemSettingsControl<CargoSettings> {
+            override fun fillUi(paintAwarePanel: PaintAwarePanel, identLevel: Int) {
+            }
+
+            override fun reset() {
+            }
+
+            override fun isModified(): Boolean {
+                return false
+            }
+
+            override fun apply(settings: CargoSettings) {
+            }
+
+            @Throws(ConfigurationException::class)
+            override fun validate(settings: CargoSettings): Boolean {
+                return true
+            }
+
+            override fun disposeUIResources() {
+            }
+
+            override fun showUi(show: Boolean) {
+            }
+        }
+    }
+}

--- a/src/org/rust/cargo/project/CargoOpenProjectDescriptor.kt
+++ b/src/org/rust/cargo/project/CargoOpenProjectDescriptor.kt
@@ -1,0 +1,16 @@
+package org.rust.cargo.project
+
+import com.intellij.ide.actions.OpenProjectFileChooserDescriptor
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.Cargo
+
+class CargoOpenProjectDescriptor : OpenProjectFileChooserDescriptor(true) {
+
+    override fun isFileVisible(file: VirtualFile, showHiddenFiles: Boolean): Boolean {
+        return super.isFileVisible(file, showHiddenFiles) && (file.isDirectory || Cargo.BUILD_FILE == file.name)
+    }
+
+    override fun isFileSelectable(file: VirtualFile): Boolean {
+        return super.isFileSelectable(file) && CargoProjectImportProvider.canImport(file)
+    }
+}

--- a/src/org/rust/cargo/project/CargoProjectImportBuilder.kt
+++ b/src/org/rust/cargo/project/CargoProjectImportBuilder.kt
@@ -1,0 +1,37 @@
+package org.rust.cargo.project
+
+import com.intellij.ide.util.projectWizard.WizardContext
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManager
+import com.intellij.openapi.externalSystem.service.project.wizard.AbstractExternalProjectImportBuilder
+import com.intellij.openapi.project.Project
+import org.rust.cargo.Cargo
+import java.io.File
+import javax.swing.Icon
+
+class CargoProjectImportBuilder(projectDataManager: ProjectDataManager) :
+        AbstractExternalProjectImportBuilder<CargoImportControl>(
+                projectDataManager, CargoImportControl(), CargoProjectSystem.ID) {
+
+    override fun getName(): String {
+        return Cargo.NAME
+    }
+
+    override fun getIcon(): Icon {
+        return Cargo.ICON
+    }
+
+    override fun doPrepare(wizardContext: WizardContext) {
+    }
+
+    override fun beforeCommit(dataNode: DataNode<ProjectData>, project: Project) {
+    }
+
+    override fun getExternalProjectConfigToUse(file: File): File {
+        return file
+    }
+
+    override fun applyExtraSettings(wizardContext: WizardContext) {
+    }
+}

--- a/src/org/rust/cargo/project/CargoProjectImportProvider.kt
+++ b/src/org/rust/cargo/project/CargoProjectImportProvider.kt
@@ -1,0 +1,45 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.service.project.wizard.AbstractExternalProjectImportProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.Cargo
+import javax.swing.Icon
+
+class CargoProjectImportProvider(builder: CargoProjectImportBuilder) :
+        AbstractExternalProjectImportProvider(builder, CargoProjectSystem.ID) {
+
+    override fun getId(): String {
+        return Cargo.ID
+    }
+
+    override fun getName(): String {
+        return Cargo.NAME
+    }
+
+    override fun getIcon(): Icon {
+        return Cargo.ICON
+    }
+
+    override fun canImport(entry: VirtualFile, project: Project?): Boolean {
+        return canImport(entry)
+    }
+
+    override fun getPathToBeImported(file: VirtualFile): String {
+        return if (file.isDirectory) file.path else file.parent.path
+    }
+
+    override fun getFileSample(): String {
+        return "<b>Cargo</b> project file (Cargo.toml)"
+    }
+
+    companion object {
+        fun canImport(entry0: VirtualFile?): Boolean {
+            var entry = entry0
+            if (entry != null && entry.isDirectory) {
+                entry = entry.findChild(Cargo.BUILD_FILE)
+            }
+            return entry != null && !entry.isDirectory && Cargo.BUILD_FILE == entry.name
+        }
+    }
+}

--- a/src/org/rust/cargo/project/CargoProjectResolver.kt
+++ b/src/org/rust/cargo/project/CargoProjectResolver.kt
@@ -1,0 +1,135 @@
+package org.rust.cargo.project
+
+import com.google.gson.Gson
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessOutputTypes
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.ExternalSystemException
+import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.project.*
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationEvent
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
+import com.intellij.openapi.externalSystem.service.project.ExternalSystemProjectResolver
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VfsUtil
+import org.apache.commons.lang.StringUtils
+import org.rust.cargo.Cargo
+import org.rust.cargo.project.model.CargoProjectInfo
+import org.rust.cargo.project.settings.CargoExecutionSettings
+import org.rust.lang.module.RustModuleType
+import java.io.File
+import java.util.*
+
+class CargoProjectResolver : ExternalSystemProjectResolver<CargoExecutionSettings> {
+    @Throws(ExternalSystemException::class, IllegalArgumentException::class, IllegalStateException::class)
+    override fun resolveProjectInfo(
+            id: ExternalSystemTaskId,
+            projectPath: String,
+            isPreviewMode: Boolean,
+            settings: CargoExecutionSettings?,
+            listener: ExternalSystemTaskNotificationListener): DataNode<ProjectData>? {
+        listener.onStatusChange(ExternalSystemTaskNotificationEvent(id, "Resolving dependencies..."))
+        val data: CargoProjectInfo
+        try {
+            val cmd = GeneralCommandLine()
+            cmd.exePath = settings!!.cargoExecutable
+            cmd.addParameter("metadata")
+            cmd.addParameters("--output-format", "json")
+            cmd.addParameters("--manifest-path", File(projectPath, Cargo.BUILD_FILE).absolutePath)
+            cmd.addParameters("--features", StringUtils.join(settings.features, ","))
+            val process = cmd.createProcess()
+            val handler = CapturingProcessHandler(process)
+            handler.addProcessListener(
+                    object : ProcessAdapter() {
+                        override fun onTextAvailable(event: ProcessEvent, outputType: Key<Any>) {
+                            if (event.text.startsWith("    Updating") || event.text.startsWith(" Downloading")) {
+                                listener.onStatusChange(ExternalSystemTaskNotificationEvent(id, event.text.trim { it <= ' ' }))
+                            } else {
+                                listener.onTaskOutput(id, event.text, outputType === ProcessOutputTypes.STDOUT)
+                            }
+                        }
+                    })
+            val output = handler.runProcess()
+            if (output.exitCode != 0) {
+                throw ExternalSystemException("Failed to execute cargo: " + output.stderr)
+            }
+            data = Gson().fromJson(output.stdout.dropWhile { c -> c != '{' }, CargoProjectInfo::class.java)
+        } catch (e: ExecutionException) {
+            throw ExternalSystemException(e)
+        }
+
+        val projectNode = DataNode(
+                ProjectKeys.PROJECT,
+                ProjectData(CargoProjectSystem.ID, data.root.name, projectPath, projectPath),
+                null)
+        val projectRoot = File(projectPath)
+        // TODO properly handle versions
+        val moduleOrLibrary = HashMap<String, DataNode<*>>()
+        for (pkg in data.packages) {
+            val packageRoot = File(pkg.manifest_path).parentFile
+            if (VfsUtil.isAncestor(projectRoot, packageRoot, false)) {
+                // Create module
+                val moduleData = ModuleData(
+                        pkg.name,
+                        CargoProjectSystem.ID,
+                        RustModuleType.RUST_MODULE,
+                        pkg.name,
+                        packageRoot.absolutePath,
+                        packageRoot.absolutePath)
+                val moduleNode = projectNode.createChild(ProjectKeys.MODULE, moduleData)
+                moduleOrLibrary.put(pkg.name, moduleNode)
+                addSourceRoot(moduleNode, packageRoot.absolutePath)
+            } else {
+                // Create library
+                val libraryData = LibraryData(CargoProjectSystem.ID, pkg.name + " " + pkg.version)
+                libraryData.addPath(LibraryPathType.BINARY, packageRoot.absolutePath)
+                libraryData.addPath(LibraryPathType.SOURCE, packageRoot.absolutePath)
+                val libraryNode = projectNode.createChild(ProjectKeys.LIBRARY, libraryData)
+                moduleOrLibrary.put(pkg.name, libraryNode)
+            }
+        }
+        // Add dependencies
+        // TODO add transitive dependencies too
+        for (pkg in data.packages) {
+            val pkgNode = moduleOrLibrary[pkg.name]!!
+            if (pkgNode.key != ProjectKeys.MODULE) {
+                // Skip dependencies for libraries
+                continue
+            }
+            for (dependency in pkg.dependencies) {
+                val dependencyNode = moduleOrLibrary[dependency.name]!!
+                if (dependencyNode.key == ProjectKeys.MODULE) {
+                    pkgNode.createChild(
+                            ProjectKeys.MODULE_DEPENDENCY,
+                            ModuleDependencyData(
+                                    pkgNode.data as ModuleData,
+                                    dependencyNode.data as ModuleData))
+                } else if (dependencyNode.key == ProjectKeys.LIBRARY) {
+                    pkgNode.createChild(
+                            ProjectKeys.LIBRARY_DEPENDENCY,
+                            LibraryDependencyData(
+                                    pkgNode.data as ModuleData,
+                                    dependencyNode.data as LibraryData,
+                                    LibraryLevel.PROJECT))
+                } else {
+                    throw AssertionError("unreachable")
+                }
+            }
+        }
+        return projectNode
+    }
+
+    private fun addSourceRoot(node: DataNode<ModuleData>, path: String) {
+        node.createChild(ProjectKeys.CONTENT_ROOT, ContentRootData(CargoProjectSystem.ID, path))
+    }
+
+    override fun cancelTask(taskId: ExternalSystemTaskId, listener: ExternalSystemTaskNotificationListener): Boolean {
+        //TODO proper cancellation
+        return false
+    }
+}

--- a/src/org/rust/cargo/project/CargoProjectSystem.kt
+++ b/src/org/rust/cargo/project/CargoProjectSystem.kt
@@ -1,0 +1,8 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import org.rust.cargo.Cargo
+
+object CargoProjectSystem {
+    val ID = ProjectSystemId(Cargo.ID, Cargo.NAME)
+}

--- a/src/org/rust/cargo/project/CargoTaskManager.kt
+++ b/src/org/rust/cargo/project/CargoTaskManager.kt
@@ -1,0 +1,28 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.model.ExternalSystemException
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
+import com.intellij.openapi.externalSystem.task.AbstractExternalSystemTaskManager
+import org.rust.cargo.project.settings.CargoExecutionSettings
+
+class CargoTaskManager : AbstractExternalSystemTaskManager<CargoExecutionSettings>() {
+    @Throws(ExternalSystemException::class)
+    override fun executeTasks(
+            id: ExternalSystemTaskId,
+            taskNames: List<String>,
+            projectPath: String,
+            settings: CargoExecutionSettings?,
+            vmOptions: List<String>,
+            scriptParameters: List<String>,
+            debuggerSetup: String?,
+            listener: ExternalSystemTaskNotificationListener) {
+
+    }
+
+    @Throws(ExternalSystemException::class)
+    override fun cancelTask(
+            id: ExternalSystemTaskId, listener: ExternalSystemTaskNotificationListener): Boolean {
+        return false
+    }
+}

--- a/src/org/rust/cargo/project/model/CargoPackageInfo.kt
+++ b/src/org/rust/cargo/project/model/CargoPackageInfo.kt
@@ -1,0 +1,8 @@
+package org.rust.cargo.project.model
+
+class CargoPackageInfo(
+        val name: String,
+        val version: String,
+        val manifest_path: String,
+        val dependencies: List<CargoPackageRef>,
+        val targets: List<CargoTarget>)

--- a/src/org/rust/cargo/project/model/CargoPackageRef.kt
+++ b/src/org/rust/cargo/project/model/CargoPackageRef.kt
@@ -1,0 +1,3 @@
+package org.rust.cargo.project.model
+
+class CargoPackageRef(val name: String, val req: String)

--- a/src/org/rust/cargo/project/model/CargoPackageRoot.kt
+++ b/src/org/rust/cargo/project/model/CargoPackageRoot.kt
@@ -1,0 +1,3 @@
+package org.rust.cargo.project.model
+
+class CargoPackageRoot(val name: String, val version: String, val features: Map<String, List<String>>?)

--- a/src/org/rust/cargo/project/model/CargoProjectInfo.kt
+++ b/src/org/rust/cargo/project/model/CargoProjectInfo.kt
@@ -1,0 +1,4 @@
+package org.rust.cargo.project.model
+
+class CargoProjectInfo(val root: CargoPackageRoot, val packages: List<CargoPackageInfo>)
+

--- a/src/org/rust/cargo/project/model/CargoTarget.kt
+++ b/src/org/rust/cargo/project/model/CargoTarget.kt
@@ -1,0 +1,3 @@
+package org.rust.cargo.project.model
+
+class CargoTarget(val name: String, val kind: List<String>, val src_path: String, val metadata: Map<String, String>)

--- a/src/org/rust/cargo/project/settings/CargoExecutionSettings.kt
+++ b/src/org/rust/cargo/project/settings/CargoExecutionSettings.kt
@@ -1,0 +1,26 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings
+
+class CargoExecutionSettings(var cargoExecutable: String, var features: List<String>) : ExternalSystemExecutionSettings() {
+
+    override fun equals(other: Any?): Boolean{
+        if (this === other) return true
+        if (other?.javaClass != javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as CargoExecutionSettings
+
+        if (cargoExecutable != other.cargoExecutable) return false
+        if (features != other.features) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int{
+        var result = super.hashCode()
+        result += 31 * result + cargoExecutable.hashCode()
+        result += 31 * result + features.hashCode()
+        return result
+    }
+}

--- a/src/org/rust/cargo/project/settings/CargoLocalSettings.kt
+++ b/src/org/rust/cargo/project/settings/CargoLocalSettings.kt
@@ -1,0 +1,25 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemLocalSettings
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.CargoProjectSystem
+
+@State(name = "CargoLocalSettings", storages = arrayOf(Storage(file = StoragePathMacros.WORKSPACE_FILE)))
+class CargoLocalSettings protected constructor(project: Project) :
+        AbstractExternalSystemLocalSettings(CargoProjectSystem.ID, project),
+        PersistentStateComponent<AbstractExternalSystemLocalSettings.State> {
+
+    override fun getState(): AbstractExternalSystemLocalSettings.State? {
+        val state = AbstractExternalSystemLocalSettings.State()
+        fillState(state)
+        return state
+    }
+
+    companion object {
+
+        fun getInstance(project: Project): CargoLocalSettings {
+            return ServiceManager.getService(project, CargoLocalSettings::class.java)
+        }
+    }
+}

--- a/src/org/rust/cargo/project/settings/CargoProjectSettings.kt
+++ b/src/org/rust/cargo/project/settings/CargoProjectSettings.kt
@@ -1,0 +1,18 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings
+
+class CargoProjectSettings : ExternalProjectSettings() {
+    var features = emptyList<String>()
+
+    protected fun copyTo(receiver: CargoProjectSettings) {
+        receiver.features = features
+        super.copyTo(receiver)
+    }
+
+    override fun clone(): ExternalProjectSettings {
+        val result = CargoProjectSettings()
+        copyTo(result)
+        return result
+    }
+}

--- a/src/org/rust/cargo/project/settings/CargoProjectSettingsListener.kt
+++ b/src/org/rust/cargo/project/settings/CargoProjectSettingsListener.kt
@@ -1,0 +1,5 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener
+
+interface CargoProjectSettingsListener : ExternalSystemSettingsListener<CargoProjectSettings>

--- a/src/org/rust/cargo/project/settings/CargoProjectSettingsListenerAdapter.kt
+++ b/src/org/rust/cargo/project/settings/CargoProjectSettingsListenerAdapter.kt
@@ -1,0 +1,7 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.externalSystem.settings.DelegatingExternalSystemSettingsListener
+import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener
+
+class CargoProjectSettingsListenerAdapter(delegate: ExternalSystemSettingsListener<CargoProjectSettings>)
+    : DelegatingExternalSystemSettingsListener<CargoProjectSettings>(delegate), CargoProjectSettingsListener

--- a/src/org/rust/cargo/project/settings/CargoSettings.kt
+++ b/src/org/rust/cargo/project/settings/CargoSettings.kt
@@ -1,0 +1,57 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings
+import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener
+import com.intellij.openapi.project.Project
+import com.intellij.util.containers.ContainerUtilRt
+import com.intellij.util.xmlb.annotations.AbstractCollection
+
+@State(name = "CargoSettings", storages = arrayOf(
+        Storage(file = StoragePathMacros.PROJECT_FILE),
+        Storage(file = StoragePathMacros.PROJECT_CONFIG_DIR + "/cargo.xml", scheme = StorageScheme.DIRECTORY_BASED)))
+class CargoSettings(project: Project) :
+        AbstractExternalSystemSettings<CargoSettings, CargoProjectSettings, CargoProjectSettingsListener>(CargoTopic.INSTANCE, project),
+        PersistentStateComponent<CargoSettingsState> {
+
+    override fun subscribe(listener: ExternalSystemSettingsListener<CargoProjectSettings>) {
+        val adapter = CargoProjectSettingsListenerAdapter(listener)
+        project.messageBus.connect(project).subscribe(CargoTopic.INSTANCE, adapter)
+    }
+
+    override fun getState(): CargoSettingsState {
+        val state = CargoSettingsState()
+        fillState(state)
+        return state
+    }
+
+    override fun loadState(state: CargoSettingsState) {
+        super.loadState(state)
+    }
+
+    override fun copyExtraSettingsFrom(settings: CargoSettings) {
+    }
+
+    override fun checkSettings(settings1: CargoProjectSettings, settings2: CargoProjectSettings) {
+    }
+
+    companion object {
+
+        fun getInstance(project: Project): CargoSettings {
+            return ServiceManager.getService(project, CargoSettings::class.java)
+        }
+    }
+}
+
+class CargoSettingsState : AbstractExternalSystemSettings.State<CargoProjectSettings> {
+    private var linkedExternalProjects: Set<CargoProjectSettings> = ContainerUtilRt.newHashSet<CargoProjectSettings>()
+
+    @AbstractCollection(surroundWithTag = false, elementTypes = arrayOf(CargoProjectSettings::class))
+    override fun getLinkedExternalProjectsSettings(): Set<CargoProjectSettings> {
+        return linkedExternalProjects
+    }
+
+    override fun setLinkedExternalProjectsSettings(set: Set<CargoProjectSettings>) {
+        linkedExternalProjects = set
+    }
+}

--- a/src/org/rust/cargo/project/settings/CargoTopic.kt
+++ b/src/org/rust/cargo/project/settings/CargoTopic.kt
@@ -1,0 +1,10 @@
+package org.rust.cargo.project.settings
+
+import com.intellij.util.messages.Topic
+
+class CargoTopic private constructor() :
+        Topic<CargoProjectSettingsListener>("Cargo-specific settings", CargoProjectSettingsListener::class.java) {
+    companion object {
+        val INSTANCE = CargoTopic()
+    }
+}

--- a/src/org/rust/lang/config/RustConfig.kt
+++ b/src/org/rust/lang/config/RustConfig.kt
@@ -1,0 +1,5 @@
+package org.rust.lang.config
+
+class RustConfig() {
+    var cargoBinary: String = "cargo"
+}

--- a/src/org/rust/lang/config/RustConfigEntry.kt
+++ b/src/org/rust/lang/config/RustConfigEntry.kt
@@ -1,0 +1,45 @@
+package org.rust.lang.config
+
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.options.ConfigurationException
+import org.jetbrains.annotations.Nls
+import org.rust.lang.i18n.RustBundle
+import javax.swing.JComponent
+
+class RustConfigEntry : Configurable {
+    private var form: RustConfigForm? = null
+    private val configService = ServiceManager.getService(RustConfigService::class.java)
+    private val config = configService.state
+
+    @Nls
+    override fun getDisplayName(): String {
+        return RustBundle.message("config.name")
+    }
+
+    override fun getHelpTopic(): String? {
+        return RustBundle.message("config.help-topic")
+    }
+
+    override fun createComponent(): JComponent? {
+        form = RustConfigForm()
+		return form
+    }
+
+    override fun isModified(): Boolean {
+        return config.cargoBinary != form!!.cargoBinary
+    }
+
+    @Throws(ConfigurationException::class)
+    override fun apply() {
+        config.cargoBinary = form!!.cargoBinary
+    }
+
+    override fun reset() {
+        form!!.cargoBinary = config.cargoBinary
+    }
+
+    override fun disposeUIResources() {
+        form = null
+    }
+}

--- a/src/org/rust/lang/config/RustConfigForm.java
+++ b/src/org/rust/lang/config/RustConfigForm.java
@@ -1,0 +1,34 @@
+package org.rust.lang.config;
+
+import org.rust.lang.i18n.RustBundle;
+
+import javax.swing.*;
+
+public class RustConfigForm extends JPanel {
+	private JLabel cargoBinaryLabel;
+	private JTextField cargoBinary;
+
+	public RustConfigForm() {
+		SpringLayout layout = new SpringLayout();
+		setLayout(layout);
+
+		add(cargoBinaryLabel = new JLabel(RustBundle.INSTANCE.message("config.label.cargo-binary")));
+		add(cargoBinary = new JTextField());
+
+		layout.putConstraint(SpringLayout.WEST, cargoBinaryLabel, 5, SpringLayout.WEST, this);
+		layout.putConstraint(SpringLayout.NORTH, cargoBinaryLabel, 5, SpringLayout.NORTH, this);
+
+		layout.putConstraint(SpringLayout.WEST, cargoBinary, 5, SpringLayout.EAST, cargoBinaryLabel);
+		layout.putConstraint(SpringLayout.NORTH, cargoBinary, 3, SpringLayout.NORTH, this);
+
+		layout.putConstraint(SpringLayout.EAST, this, 5, SpringLayout.EAST, cargoBinary);
+	}
+
+	public String getCargoBinary() {
+		return cargoBinary.getText();
+	}
+
+	public void setCargoBinary(String cargoBinary) {
+		this.cargoBinary.setText(cargoBinary);
+	}
+}

--- a/src/org/rust/lang/config/RustConfigService.kt
+++ b/src/org/rust/lang/config/RustConfigService.kt
@@ -1,0 +1,20 @@
+package org.rust.lang.config
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.StoragePathMacros
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(name = "Rust", storages = arrayOf(Storage(id = "other", file = StoragePathMacros.APP_CONFIG + "Rust.xml")))
+class RustConfigService : PersistentStateComponent<RustConfig> {
+    private val config = RustConfig()
+
+    override fun getState(): RustConfig {
+        return config
+    }
+
+    override fun loadState(config: RustConfig) {
+        XmlSerializerUtil.copyBean(config, this.config)
+    }
+}

--- a/src/org/rust/lang/i18n/RustBundle.kt
+++ b/src/org/rust/lang/i18n/RustBundle.kt
@@ -1,0 +1,17 @@
+package org.rust.lang.i18n
+
+import com.intellij.CommonBundle
+import org.jetbrains.annotations.PropertyKey
+import java.util.*
+
+object RustBundle {
+    private const val BUNDLE_NAME = "org.rust.lang.i18n.RustBundle"
+
+    public val BUNDLE by lazy {
+        ResourceBundle.getBundle(BUNDLE_NAME)
+    }
+
+    public fun message(@PropertyKey(resourceBundle = BUNDLE_NAME) key: String, vararg params: Any): String {
+        return CommonBundle.message(BUNDLE, key, params)
+    }
+}


### PR DESCRIPTION
Port of https://github.com/Vektah/idea-rust/pull/42.

Implements cargo project (auto)import, creates a module for each cargo dependency under project root and a library for each dependency outside of the project root.

Relies on cargo metadata subcommand, which is available at https://github.com/winger/cargo-metadata and (hopefully) soon will be installable with cargo install cargo-metadata (after https://github.com/rust-lang/cargo/pull/2091 will be checked in).

