### PR TITLE
Add basic DocumentationProvider implementation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
         <lang.commenter language="RUST" implementationClass="org.rust.lang.RustCommenter"/>
         <lang.braceMatcher language="RUST" implementationClass="org.rust.lang.highlight.RustBraceMatcher"/>
         <lang.quoteHandler language="RUST" implementationClass="org.rust.lang.RustQuoteHandler"/>
+        <lang.documentationProvider language="RUST" implementationClass="org.rust.lang.RustDocumentationProvider"/>
 
         <lang.parserDefinition language="RUST" implementationClass="org.rust.lang.core.RustParserDefinition"/>
 

--- a/src/org/rust/lang/RustDocumentationProvider.kt
+++ b/src/org/rust/lang/RustDocumentationProvider.kt
@@ -1,0 +1,24 @@
+package org.rust.lang
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RustBindingMode
+import org.rust.lang.core.psi.RustPatIdent
+
+class RustDocumentationProvider : AbstractDocumentationProvider() {
+
+    override fun getQuickNavigateInfo(element: PsiElement?, originalElement: PsiElement?): String? {
+        if (element is RustPatIdent) {
+            val location = getLocationString(element)
+            val bindingMode = element.bindingMode?.mut?.let { "mut " }.orEmpty()
+
+            return "let $bindingMode<b>${element.identifier.text}</b>$location"
+        }
+        return null
+    }
+
+    private fun getLocationString(element: PsiElement?): String {
+        return element?.containingFile?.let { " [${it.name}]" }.orEmpty()
+    }
+}

--- a/test/org/rust/lang/RustDocumentationProviderTest.kt
+++ b/test/org/rust/lang/RustDocumentationProviderTest.kt
@@ -1,0 +1,26 @@
+package org.rust.lang
+
+import com.intellij.codeInsight.documentation.DocumentationManager
+import com.intellij.openapi.util.io.FileUtil
+import org.assertj.core.api.Assertions.assertThat
+import java.io.File
+
+class RustDocumentationProviderTest : RustTestCase() {
+    override fun getTestDataPath() = "testData/documentation"
+
+    private fun doTest(expected: String) {
+        myFixture.configureByFile(fileName)
+        val originalElement = myFixture.elementAtCaret
+        val element = DocumentationManager.getInstance(project).findTargetElement(myFixture.editor, myFixture.file)
+        val doc = RustDocumentationProvider().getQuickNavigateInfo(element, originalElement)
+        assertThat(doc).isEqualTo(expected);
+    }
+
+    private fun doFileTest() {
+        val text = FileUtil.loadFile(File(testDataPath + "/" + fileName.replace(".rs", ".html"))).trim()
+        doTest(text)
+    }
+
+    fun testVariable1() = doFileTest()
+    fun testVariable2() = doFileTest()
+}

--- a/testData/documentation/variable1.html
+++ b/testData/documentation/variable1.html
@@ -1,0 +1,1 @@
+let <b>xyz</b> [variable1.rs]

--- a/testData/documentation/variable1.rs
+++ b/testData/documentation/variable1.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let xy<caret>z = 42;
+    do_something(xyz);
+}

--- a/testData/documentation/variable2.html
+++ b/testData/documentation/variable2.html
@@ -1,0 +1,1 @@
+let mut <b>xyz</b> [variable2.rs]

--- a/testData/documentation/variable2.rs
+++ b/testData/documentation/variable2.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let mut xyz = 42;
+    do_something(x<caret>yz);
+}


### PR DESCRIPTION
This PR adds a veeeery basic implementation of the `DocumentationProvider` interface for local variables and parameters.