### PR TITLE
(CI): add appveyor for windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Rust IDE built using the IntelliJ Platform
 
-[![Build Status](https://img.shields.io/travis/alexeykudinkin/intellij-rust/master.svg)](https://travis-ci.org/alexeykudinkin/intellij-rust) [![Join the chat at https://gitter.im/alexeykudinkin/intellij-rust](https://img.shields.io/badge/Gitter-Join%20Chat-blue.svg)](https://gitter.im/alexeykudinkin/intellij-rust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
+[![Build Status Travis](https://img.shields.io/travis/alexeykudinkin/intellij-rust/master.svg?label=TravisCI)](https://travis-ci.org/alexeykudinkin/intellij-rust)
+[![Build Status Appveyor](https://img.shields.io/appveyor/ci/alexeykudinkin/intellij-rust/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/alexeykudinkin/intellij-rust/branch/master)
+[![Join the chat at https://gitter.im/alexeykudinkin/intellij-rust](https://img.shields.io/badge/Gitter-Join%20Chat-blue.svg)](https://gitter.im/alexeykudinkin/intellij-rust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
 **BEWARE**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{branch} {build}"
+
+install:
+  - git submodule update --init --recursive
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat assemble --no-daemon
+
+test_script:
+  - gradlew.bat test check --no-daemon
+
+# Disable, because cache size exceeds 500 mb
+# cache:
+#  - C:\Users\appveyor\.gradle


### PR DESCRIPTION
Add [Appveyor](http://www.appveyor.com/) for windows build. 

@alexeykudinkin you should add a webhook to launch the build on commit (not sure about this).  


I don't know if travis + appveyor is the best way to do CI, but it seems ok so far.