### PR TITLE
Resolve items

### DIFF
--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -152,6 +152,9 @@
     // Resolve scopes
     //
 
+    implements  ("mod_item") = "org.rust.lang.core.resolve.scope.RustResolveScope"
+    mixin       ("mod_item") = "org.rust.lang.core.psi.impl.mixin.RustModItemImplMixin"
+
     implements  ("fn_item") = ["org.rust.lang.core.psi.RustItem"
                                "org.rust.lang.core.resolve.scope.RustResolveScope"]
     mixin       ("fn_item") = "org.rust.lang.core.psi.impl.mixin.RustFnItemImplMixin"

--- a/src/org/rust/lang/core/psi/RustItem.kt
+++ b/src/org/rust/lang/core/psi/RustItem.kt
@@ -1,6 +1,6 @@
 package org.rust.lang.core.psi
 
-public interface RustItem : RustNamedElement {
+public interface RustItem : RustNamedElement, RustDeclaringElement {
 
     val attrs : List<RustOuterAttr>?
         get

--- a/src/org/rust/lang/core/psi/extensions.kt
+++ b/src/org/rust/lang/core/psi/extensions.kt
@@ -1,6 +1,22 @@
 package org.rust.lang.core.psi
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.psi.util.RecursiveRustVisitor
 
 val RustModItem.items: List<RustItem>
     get() = PsiTreeUtil.getChildrenOfTypeAsList(this, RustItem::class.java)
+
+val RustPat.boundElements: List<RustNamedElement>
+    get() {
+        val result = arrayListOf<RustNamedElement>()
+
+        accept(object : RecursiveRustVisitor() {
+            override fun visitElement(element: PsiElement?) {
+                if (element is RustNamedElement)
+                    result.add(element)
+                super.visitElement(element)
+            }
+        })
+        return result
+    }

--- a/src/org/rust/lang/core/psi/extensions.kt
+++ b/src/org/rust/lang/core/psi/extensions.kt
@@ -1,0 +1,6 @@
+package org.rust.lang.core.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+
+val RustModItem.items: List<RustItem>
+    get() = PsiTreeUtil.getChildrenOfTypeAsList(this, RustItem::class.java)

--- a/src/org/rust/lang/core/psi/impl/RustItemImpl.kt
+++ b/src/org/rust/lang/core/psi/impl/RustItemImpl.kt
@@ -1,10 +1,7 @@
 package org.rust.lang.core.psi.impl
 
 import com.intellij.lang.ASTNode
-import org.rust.lang.core.psi.RustCompositeElementTypes
-import org.rust.lang.core.psi.RustItem
-import org.rust.lang.core.psi.RustOuterAttr
-import org.rust.lang.core.psi.RustVis
+import org.rust.lang.core.psi.*
 
 public abstract class RustItemImpl(node: ASTNode)   : RustNamedElementImpl(node)
                                                     , RustItem {
@@ -14,5 +11,7 @@ public abstract class RustItemImpl(node: ASTNode)   : RustNamedElementImpl(node)
 
     override val vis: RustVis?
         get() = findChildByType(RustCompositeElementTypes.VIS)
+
+    override fun getBoundElements(): Collection<RustNamedElement> = listOf(this)
 }
 

--- a/src/org/rust/lang/core/psi/impl/mixin/RustAnonParamImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustAnonParamImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustAnonParam
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustAnonParamImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
                                                             , RustAnonParam {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustLambdaParamImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustLambdaParamImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustLambdaParam
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustLambdaParamImplMixin(node: ASTNode)   : RustCompositeElementImpl(node)
                                                                 , RustLambdaParam {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustLetDeclImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustLetDeclImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustLetDecl
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustLetDeclImplMixin(node: ASTNode)   : RustCompositeElementImpl(node)
                                                             , RustLetDecl {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustMatchPatImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustMatchPatImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustMatchPat
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustMatchPatImplMixin(node: ASTNode)  : RustCompositeElementImpl(node)
                                                             , RustMatchPat {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustModItemImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustModItemImplMixin.kt
@@ -1,0 +1,15 @@
+package org.rust.lang.core.psi.impl.mixin
+
+import com.intellij.lang.ASTNode
+import org.rust.lang.core.psi.RustDeclaringElement
+import org.rust.lang.core.psi.RustModItem
+import org.rust.lang.core.psi.impl.RustItemImpl
+import org.rust.lang.core.psi.items
+
+abstract class RustModItemImplMixin(node: ASTNode) : RustItemImpl(node)
+        , RustModItem {
+
+    override fun getDeclarations(): Collection<RustDeclaringElement> {
+        return items
+    }
+}

--- a/src/org/rust/lang/core/psi/impl/mixin/RustParamImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustParamImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustParam
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustParamImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
                                                         , RustParam {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustPatFieldImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustPatFieldImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustPatField
 import org.rust.lang.core.psi.impl.RustNamedElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustPatFieldImplMixin(node: ASTNode)  : RustNamedElementImpl(node)
                                                             , RustPatField {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustScopedForDeclImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustScopedForDeclImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustScopedForDecl
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustScopedForDeclImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
                                                                 , RustScopedForDecl {

--- a/src/org/rust/lang/core/psi/impl/mixin/RustScopedLetDeclImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustScopedLetDeclImplMixin.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.RustScopedLetDecl
 import org.rust.lang.core.psi.impl.RustCompositeElementImpl
-import org.rust.lang.core.psi.util.boundElements
+import org.rust.lang.core.psi.boundElements
 
 public abstract class RustScopedLetDeclImplMixin(node: ASTNode) : RustCompositeElementImpl(node)
                                                                 , RustScopedLetDecl {

--- a/src/org/rust/lang/core/psi/util/RustPsiUtil.kt
+++ b/src/org/rust/lang/core/psi/util/RustPsiUtil.kt
@@ -2,8 +2,6 @@ package org.rust.lang.core.psi.util
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RustNamedElement
-import org.rust.lang.core.psi.RustPat
 
 
 //
@@ -19,20 +17,6 @@ fun PsiElement?.match(s: String?): Boolean {
 val PsiElement.parentRelativeRange: TextRange?
     get() = this.parent?.let {
         TextRange(startOffsetInParent, startOffsetInParent + textLength)
-    }
-
-val RustPat.boundElements: List<RustNamedElement>
-    get() {
-        val result = arrayListOf<RustNamedElement>()
-
-        accept(object : RecursiveRustVisitor() {
-            override fun visitElement(element: PsiElement?) {
-                if (element is RustNamedElement)
-                    result.add(element)
-                super.visitElement(element)
-            }
-        })
-        return result
     }
 
 fun PsiElement.isBefore(other: PsiElement): Boolean = textOffset < other.textOffset

--- a/src/org/rust/lang/core/psi/util/RustPsiUtil.kt
+++ b/src/org/rust/lang/core/psi/util/RustPsiUtil.kt
@@ -34,3 +34,5 @@ val RustPat.boundElements: List<RustNamedElement>
         })
         return result
     }
+
+fun PsiElement.isBefore(other: PsiElement): Boolean = textOffset < other.textOffset

--- a/test/org/rust/lang/core/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/RustResolveTestCase.kt
@@ -25,7 +25,8 @@ class RustResolveTestCase : RustTestCase() {
     fun testTraitMethodArgument()  { checkIsBound()   }
     fun testImplMethodArgument()   { checkIsBound()   }
     fun testStructPatterns1()      { checkIsBound(atOffset = 69) }
-    fun testStructPatterns2()      { checkIsBound() }
+    fun testStructPatterns2()      { checkIsBound()   }
+    fun testModItem()              { checkIsBound()   }
     fun testUnbound()              { checkIsUnbound() }
     fun testOrdering()             { checkIsUnbound() }
     //@formatter:on

--- a/test/org/rust/lang/core/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/RustResolveTestCase.kt
@@ -26,7 +26,7 @@ class RustResolveTestCase : RustTestCase() {
     fun testImplMethodArgument()   { checkIsBound()   }
     fun testStructPatterns1()      { checkIsBound(atOffset = 69) }
     fun testStructPatterns2()      { checkIsBound()   }
-    fun testModItem()              { checkIsBound()   }
+    fun testModItems()             { checkIsBound()   }
     fun testUnbound()              { checkIsUnbound() }
     fun testOrdering()             { checkIsUnbound() }
     //@formatter:on
@@ -35,7 +35,8 @@ class RustResolveTestCase : RustTestCase() {
                                          expectedOffset: Int?) {
 
         assertThat(declaration).isInstanceOf(RustNamedElement::class.java)
-        assertThat(declaration.text).isEqualTo(usage.canonicalText)
+        declaration as RustNamedElement
+        assertThat(declaration.name).isEqualTo(usage.canonicalText)
 
         if (expectedOffset != null) {
             assertThat(declaration.textRange.startOffset).isEqualTo(expectedOffset)

--- a/testData/resolve/mod_items.rs
+++ b/testData/resolve/mod_items.rs
@@ -1,0 +1,9 @@
+mod m {
+    fn main() {
+        fo<caret>o()
+    }
+
+    fn foo() {
+
+    }
+}


### PR DESCRIPTION
This starts resolve for modules and items.

It  relays on the extension method to get `items` out of the `mod`, but it could be trivially removed once the generated `RustModItem` has the necessary method.

@alexeykudinkin please review

