### PR TITLE
Enable spellchecking for Rust files

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -46,6 +46,8 @@
 
         <annotator language="RUST" implementationClass="org.rust.lang.annotator.RustAnnotator"/>
 
+        <spellchecker.support language="RUST" implementationClass="org.rust.lang.spellchecker.RustSpellcheckingStrategy"/>
+
         <colorSettingsPage implementation="org.rust.lang.colorscheme.RustColorSettingsPage"/>
 
         <additionalTextAttributes scheme="Default" file="org/rust/colorscheme/RustDefault.xml"/>

--- a/src/org/rust/lang/spellchecker/LiteralExpressionTokenizer.kt
+++ b/src/org/rust/lang/spellchecker/LiteralExpressionTokenizer.kt
@@ -1,0 +1,30 @@
+package org.rust.lang.spellchecker
+
+import com.intellij.psi.impl.source.tree.java.PsiLiteralExpressionImpl
+import com.intellij.spellchecker.inspections.PlainTextSplitter
+import com.intellij.spellchecker.tokenizer.EscapeSequenceTokenizer
+import com.intellij.spellchecker.tokenizer.TokenConsumer
+import org.rust.lang.core.psi.RustLitExpr
+
+class LiteralExpressionTokenizer : EscapeSequenceTokenizer<RustLitExpr>() {
+
+    override fun tokenize(element: RustLitExpr, consumer: TokenConsumer) {
+        val text = element.stringLiteral?.text ?: return
+
+        if ("\\" !in text) {
+            consumer.consumeToken(element, PlainTextSplitter.getInstance())
+        } else {
+            processTextWithEscapeSequences(element, text, consumer)
+        }
+    }
+
+    companion object {
+        fun processTextWithEscapeSequences(element: RustLitExpr, text: String, consumer: TokenConsumer) {
+            val unescapedText = StringBuilder()
+            val offsets = IntArray(text.length + 1)
+            PsiLiteralExpressionImpl.parseStringCharacters(text, unescapedText, offsets)
+
+            processTextWithOffsets(element, consumer, unescapedText, offsets, 1)
+        }
+    }
+}

--- a/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
+++ b/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
@@ -2,8 +2,20 @@ package org.rust.lang.spellchecker
 
 import com.intellij.psi.PsiElement
 import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import com.intellij.spellchecker.tokenizer.Tokenizer
 import org.rust.lang.RustLanguage
+import org.rust.lang.core.psi.RustLitExpr
 
 class RustSpellcheckingStrategy : SpellcheckingStrategy() {
+    private val literalExpressionTokenizer = LiteralExpressionTokenizer()
+
     override fun isMyContext(element: PsiElement) = RustLanguage.INSTANCE.`is`(element.language)
+
+    override fun getTokenizer(element: PsiElement?): Tokenizer<*> {
+        if (element is RustLitExpr) {
+            return literalExpressionTokenizer
+        }
+        return super.getTokenizer(element)
+    }
 }
+

--- a/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
+++ b/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
@@ -1,0 +1,9 @@
+package org.rust.lang.spellchecker
+
+import com.intellij.psi.PsiElement
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import org.rust.lang.RustLanguage
+
+class RustSpellcheckingStrategy : SpellcheckingStrategy() {
+    override fun isMyContext(element: PsiElement) = RustLanguage.INSTANCE.`is`(element.language)
+}


### PR DESCRIPTION
This only works for comments as of now, but can be extended to work for strings and identifiers as well.

![bildschirmfoto 2015-11-06 um 16 23 41](https://cloud.githubusercontent.com/assets/141300/11000558/c641161a-84a2-11e5-9396-4f2e5af23590.png)
