### PR TITLE
"Rust SDK" SdkType implementation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -32,6 +32,8 @@
 
         <fileTypeFactory implementation="org.rust.lang.RustFileTypeFactory"/>
 
+        <sdkType implementation="org.rust.lang.RustSdkType"/>
+
         <lang.syntaxHighlighterFactory language="RUST" implementationClass="org.rust.lang.highlight.RustHighlighterFactory"/>
         <lang.formatter language="RUST" implementationClass="org.rust.lang.formatter.RustFormattingModelBuilder"/>
         <lang.commenter language="RUST" implementationClass="org.rust.lang.RustCommenter"/>

--- a/src/org/rust/lang/RustSdkType.kt
+++ b/src/org/rust/lang/RustSdkType.kt
@@ -21,7 +21,16 @@ class RustSdkType : SdkType("Rust SDK") {
     override fun getIcon() = RustIcons.FILE
     override fun getIconForAddAction() = icon
 
-    override fun suggestHomePath() = null
+    override fun suggestHomePath(): String? {
+        if (SystemInfo.isMac) {
+            // look for rust installed by homebrew
+            val homebrew = File("/usr/local/Cellar/rust")
+            if (homebrew.exists())
+                return homebrew.absolutePath
+        }
+
+        return null
+    }
 
     override fun isValidSdkHome(path: String): Boolean {
         val rustc = getSdkExecutable(path, "rustc")

--- a/src/org/rust/lang/RustSdkType.kt
+++ b/src/org/rust/lang/RustSdkType.kt
@@ -41,9 +41,8 @@ class RustSdkType : SdkType("Rust SDK") {
     override fun adjustSelectedSdkHome(homePath: String?): String? {
         val file = File(homePath)
         return when (file.nameWithoutExtension) {
-            "rustc", "cargo" -> file.parentFile.absolutePath
-            "bin"            -> file.parentFile.absolutePath
-            else             -> super.adjustSelectedSdkHome(homePath)
+            "bin" -> file.parentFile.absolutePath
+            else  -> super.adjustSelectedSdkHome(homePath)
         }
     }
 

--- a/src/org/rust/lang/RustSdkType.kt
+++ b/src/org/rust/lang/RustSdkType.kt
@@ -52,18 +52,18 @@ class RustSdkType : SdkType("Rust SDK") {
     }
 
     private fun getExecutableFileName(executableName: String): String {
-        return if (SystemInfo.isWindows) executableName + ".exe" else executableName
+        return if (SystemInfo.isWindows) "$executableName.exe" else executableName
     }
 
     override fun suggestSdkName(currentSdkName: String?, sdkHome: String) =
-            getVersionString(sdkHome)?.let { "Rust " + it }
-                    ?: "Unknown Rust version at " + sdkHome
+            getVersionString(sdkHome)?.let { "Rust $it" }
+                    ?: "Unknown Rust version at $sdkHome"
 
     override fun getVersionString(sdkHome: String): String? {
         val rustc = getSdkExecutable(sdkHome, "rustc")
         if (!rustc.canExecute()) {
-            val reason = rustc.path + (if (rustc.exists()) " is not executable." else " is missing.")
-            LOG.warn("Can't detect rustc version: " + reason)
+            val reason = "${rustc.path}${if (rustc.exists()) " is not executable." else " is missing."}"
+            LOG.warn("Can't detect rustc version: $reason")
             return null
         }
 
@@ -78,7 +78,7 @@ class RustSdkType : SdkType("Rust SDK") {
                 return null
 
             val line = output.stdoutLines.firstOrNull()
-            LOG.debug("rustc --version returned: " + line)
+            LOG.debug("rustc --version returned: $line")
 
             val matcher = RE_VERSION.matcher(line)
             if (!matcher.matches())

--- a/src/org/rust/lang/RustSdkType.kt
+++ b/src/org/rust/lang/RustSdkType.kt
@@ -29,6 +29,15 @@ class RustSdkType : SdkType("Rust SDK") {
         return rustc.canExecute() && cargo.canExecute()
     }
 
+    override fun adjustSelectedSdkHome(homePath: String?): String? {
+        val file = File(homePath)
+        return when (file.nameWithoutExtension) {
+            "rustc", "cargo" -> file.parentFile.absolutePath
+            "bin"            -> file.parentFile.absolutePath
+            else             -> super.adjustSelectedSdkHome(homePath)
+        }
+    }
+
     private fun getSdkExecutable(sdkHome: String, command: String): File {
         return File(File(sdkHome, "bin"), getExecutableFileName(command))
     }

--- a/src/org/rust/lang/RustSdkType.kt
+++ b/src/org/rust/lang/RustSdkType.kt
@@ -1,0 +1,87 @@
+package org.rust.lang
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.projectRoots.SdkAdditionalData
+import com.intellij.openapi.projectRoots.SdkModel
+import com.intellij.openapi.projectRoots.SdkModificator
+import com.intellij.openapi.projectRoots.SdkType
+import com.intellij.openapi.util.SystemInfo
+import org.jdom.Element
+import org.rust.lang.icons.RustIcons
+import java.io.File
+import java.util.concurrent.ExecutionException
+import java.util.regex.Pattern
+
+class RustSdkType : SdkType("Rust SDK") {
+
+    override fun getPresentableName() = name
+
+    override fun getIcon() = RustIcons.FILE
+    override fun getIconForAddAction() = icon
+
+    override fun suggestHomePath() = null
+
+    override fun isValidSdkHome(path: String): Boolean {
+        val rustc = getSdkExecutable(path, "rustc")
+        val cargo = getSdkExecutable(path, "cargo")
+        return rustc.canExecute() && cargo.canExecute()
+    }
+
+    private fun getSdkExecutable(sdkHome: String, command: String): File {
+        return File(File(sdkHome, "bin"), getExecutableFileName(command))
+    }
+
+    private fun getExecutableFileName(executableName: String): String {
+        return if (SystemInfo.isWindows) executableName + ".exe" else executableName
+    }
+
+    override fun suggestSdkName(currentSdkName: String?, sdkHome: String) =
+            getVersionString(sdkHome)?.let { "Rust " + it }
+                    ?: "Unknown Rust version at " + sdkHome
+
+    override fun getVersionString(sdkHome: String): String? {
+        val rustc = getSdkExecutable(sdkHome, "rustc")
+        if (!rustc.canExecute()) {
+            val reason = rustc.path + (if (rustc.exists()) " is not executable." else " is missing.")
+            LOG.warn("Can't detect rustc version: " + reason)
+            return null
+        }
+
+        try {
+            val cmd = GeneralCommandLine()
+                    .withWorkDirectory(sdkHome)
+                    .withExePath(rustc.absolutePath)
+                    .withParameters("--version")
+
+            val output = CapturingProcessHandler(cmd.createProcess()).runProcess(10 * 1000)
+            if (output.exitCode != 0 || output.isCancelled || output.isTimeout)
+                return null
+
+            val line = output.stdoutLines.firstOrNull()
+            LOG.debug("rustc --version returned: " + line)
+
+            val matcher = RE_VERSION.matcher(line)
+            if (!matcher.matches())
+                return null
+
+            return matcher.group(1)
+
+        } catch (e: ExecutionException) {
+            LOG.warn(e);
+            return null;
+        }
+    }
+
+    override fun createAdditionalDataConfigurable(sdkModel: SdkModel, sdkModificator: SdkModificator) = null
+    override fun saveAdditionalData(additionalData: SdkAdditionalData, additional: Element) {
+    }
+
+    companion object {
+        val LOG = Logger.getInstance(RustSdkType::class.java)
+        val RE_VERSION = Pattern.compile("rustc (\\d+\\.\\d+\\.\\d).*")
+
+        fun getInstance() = SdkType.findInstance(RustSdkType::class.java)
+    }
+}


### PR DESCRIPTION
This PR adds a basic `SdkType` implementation for the Rust language. I guess this can later be used to run specific versions of `rustc` and/or `cargo` for various sorts of tasks.