### PR TITLE
Move user-facing strings into RustBundle.properties file

### DIFF
--- a/resources/org/rust/lang/i18n/RustBundle.properties
+++ b/resources/org/rust/lang/i18n/RustBundle.properties
@@ -1,0 +1,23 @@
+rust.display_name = Rust
+rust.module.display_name = Rust
+rust.files.display_name = Rust Files
+
+rust.settings.colors.identifier = Identifier
+rust.settings.colors.lifetime = Lifetime
+rust.settings.colors.char = Char
+rust.settings.colors.string = String
+rust.settings.colors.number = Number
+rust.settings.colors.keyword = Keyword
+rust.settings.colors.block_comment = Block comment
+rust.settings.colors.eol_comment = Line comment
+rust.settings.colors.doc_comment = Doc comment
+rust.settings.colors.parenthesis = Parenthesis
+rust.settings.colors.brackets = Brackets
+rust.settings.colors.braces = Braces
+rust.settings.colors.operators = Operator sign
+rust.settings.colors.semicolon = Semicolon
+rust.settings.colors.dot = Dot
+rust.settings.colors.comma = Comma
+rust.settings.colors.attribute = Attribute
+rust.settings.colors.macro = Macro
+rust.settings.colors.type_parameter = Type Parameter

--- a/src/org/rust/lang/RustFileType.kt
+++ b/src/org/rust/lang/RustFileType.kt
@@ -2,6 +2,7 @@ package org.rust.lang
 
 import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.vfs.VirtualFile
+import org.rust.lang.i18n.RustBundle
 import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
@@ -13,7 +14,7 @@ public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
         public val EXTENSION: String = "rs";
     }
 
-    override fun getName(): String = "Rust"
+    override fun getName(): String = RustBundle.message("rust.display_name")
 
     override fun getIcon(): Icon = RustIcons.FILE;
 
@@ -22,9 +23,7 @@ public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
     override fun getCharset(file: VirtualFile, content: ByteArray): String =
             "UTF-8"
 
-    override fun getDescription(): String {
-        return "Rust Files"
-    }
+    override fun getDescription() = RustBundle.message("rust.files.display_name")
 
 }
 

--- a/src/org/rust/lang/colorscheme/RustColorSettingsPage.kt
+++ b/src/org/rust/lang/colorscheme/RustColorSettingsPage.kt
@@ -6,30 +6,31 @@ import com.intellij.openapi.options.colors.ColorDescriptor
 import com.intellij.openapi.options.colors.ColorSettingsPage
 import com.intellij.openapi.util.io.StreamUtil
 import org.rust.lang.highlight.RustHighlighter
+import org.rust.lang.i18n.RustBundle
 import org.rust.lang.icons.RustIcons
 
 public class RustColorSettingsPage : ColorSettingsPage {
     private fun d(displayName: String, key: TextAttributesKey) = AttributesDescriptor(displayName, key)
     private val ATTRS = arrayOf(
-            d("Identifier", RustColors.IDENTIFIER),
-            d("Lifetime", RustColors.LIFETIME),
-            d("Char", RustColors.CHAR),
-            d("String", RustColors.STRING),
-            d("Number", RustColors.NUMBER),
-            d("Keyword", RustColors.KEYWORD),
-            d("Block comment", RustColors.BLOCK_COMMENT),
-            d("Line comment", RustColors.EOL_COMMENT),
-            d("Doc comment", RustColors.DOC_COMMENT),
-            d("Parenthesis", RustColors.PARENTHESIS),
-            d("Brackets", RustColors.BRACKETS),
-            d("Braces", RustColors.BRACES),
-            d("Operator sign", RustColors.OPERATORS),
-            d("Semicolon", RustColors.SEMICOLON),
-            d("Dot", RustColors.DOT),
-            d("Comma", RustColors.COMMA),
-            d("Attribute", RustColors.ATTRIBUTE),
-            d("Macro", RustColors.MACRO),
-            d("Type Parameter", RustColors.TYPE_PARAMETER)
+            d(RustBundle.message("rust.settings.colors.identifier"), RustColors.IDENTIFIER),
+            d(RustBundle.message("rust.settings.colors.lifetime"), RustColors.LIFETIME),
+            d(RustBundle.message("rust.settings.colors.char"), RustColors.CHAR),
+            d(RustBundle.message("rust.settings.colors.string"), RustColors.STRING),
+            d(RustBundle.message("rust.settings.colors.number"), RustColors.NUMBER),
+            d(RustBundle.message("rust.settings.colors.keyword"), RustColors.KEYWORD),
+            d(RustBundle.message("rust.settings.colors.block_comment"), RustColors.BLOCK_COMMENT),
+            d(RustBundle.message("rust.settings.colors.eol_comment"), RustColors.EOL_COMMENT),
+            d(RustBundle.message("rust.settings.colors.doc_comment"), RustColors.DOC_COMMENT),
+            d(RustBundle.message("rust.settings.colors.parenthesis"), RustColors.PARENTHESIS),
+            d(RustBundle.message("rust.settings.colors.brackets"), RustColors.BRACKETS),
+            d(RustBundle.message("rust.settings.colors.braces"), RustColors.BRACES),
+            d(RustBundle.message("rust.settings.colors.operators"), RustColors.OPERATORS),
+            d(RustBundle.message("rust.settings.colors.semicolon"), RustColors.SEMICOLON),
+            d(RustBundle.message("rust.settings.colors.dot"), RustColors.DOT),
+            d(RustBundle.message("rust.settings.colors.comma"), RustColors.COMMA),
+            d(RustBundle.message("rust.settings.colors.attribute"), RustColors.ATTRIBUTE),
+            d(RustBundle.message("rust.settings.colors.macro"), RustColors.MACRO),
+            d(RustBundle.message("rust.settings.colors.type_parameter"), RustColors.TYPE_PARAMETER)
     )
     private val TAGS = emptyMap<String, TextAttributesKey>()
     private val DEMO_TEXT by lazy {
@@ -37,7 +38,7 @@ public class RustColorSettingsPage : ColorSettingsPage {
         StreamUtil.readText(stream, "UTF-8")
     }
 
-    override fun getDisplayName() = "Rust"
+    override fun getDisplayName() = RustBundle.message("rust.display_name")
     override fun getIcon() = RustIcons.FILE
     override fun getAttributeDescriptors() = ATTRS
     override fun getColorDescriptors() = ColorDescriptor.EMPTY_ARRAY

--- a/src/org/rust/lang/i18n/RustBundle.kt
+++ b/src/org/rust/lang/i18n/RustBundle.kt
@@ -1,0 +1,17 @@
+package org.rust.lang.i18n
+
+import com.intellij.CommonBundle
+import org.jetbrains.annotations.PropertyKey
+import java.util.*
+
+object RustBundle {
+    private const val BUNDLE_NAME = "org.rust.lang.i18n.RustBundle"
+
+    public val BUNDLE by lazy {
+        ResourceBundle.getBundle(BUNDLE_NAME)
+    }
+
+    public fun message(@PropertyKey(resourceBundle = BUNDLE_NAME) key: String, vararg params: Any): String {
+        return CommonBundle.message(BUNDLE, key, params)
+    }
+}

--- a/src/org/rust/lang/module/RustModuleBuilder.kt
+++ b/src/org/rust/lang/module/RustModuleBuilder.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.module.StdModuleTypes
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider
+import org.rust.lang.i18n.RustBundle
 import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
@@ -21,9 +22,9 @@ public class RustModuleBuilder() : ModuleBuilder() {
 
     override fun getBigIcon(): Icon = RustIcons.FILE_BIG
 
-    override fun getGroupName(): String? = "Rust"
+    override fun getGroupName() = RustBundle.message("rust.display_name")
 
-    override fun getPresentableName(): String? = "Rust"
+    override fun getPresentableName() = RustBundle.message("rust.display_name")
 
     override fun createWizardSteps(wizardContext: WizardContext, modulesProvider: ModulesProvider): Array<ModuleWizardStep> =
         moduleType.createWizardSteps(wizardContext, this, modulesProvider)

--- a/src/org/rust/lang/module/RustModuleType.kt
+++ b/src/org/rust/lang/module/RustModuleType.kt
@@ -1,6 +1,7 @@
 package org.rust.lang.module
 
 import com.intellij.openapi.module.ModuleType
+import org.rust.lang.i18n.RustBundle
 import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
@@ -11,13 +12,8 @@ public class RustModuleType() : ModuleType<RustModuleBuilder>(RustModuleType.RUS
         return RustModuleBuilder()
     }
 
-    override fun getName(): String {
-        return "Rust Module"
-    }
-
-    override fun getDescription(): String {
-        return "Rust Module"
-    }
+    override fun getName() = RustBundle.message("rust.module.display_name")
+    override fun getDescription() = RustBundle.message("rust.module.display_name")
 
     override fun getBigIcon(): Icon {
         return RustIcons.FILE_BIG


### PR DESCRIPTION
Extracted from #38 and reduced to the currently used strings