### PR TITLE
Highlighter cleanup

### DIFF
--- a/src/org/rust/lang/highlight/RustHighlighter.kt
+++ b/src/org/rust/lang/highlight/RustHighlighter.kt
@@ -1,7 +1,5 @@
 package org.rust.lang.highlight
 
-import com.intellij.lexer.Lexer
-import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.colorscheme.RustColors
@@ -10,46 +8,40 @@ import org.rust.lang.core.lexer.RustLexer
 import org.rust.lang.core.lexer.RustTokenElementTypes.*
 
 public class RustHighlighter : SyntaxHighlighterBase() {
-    override fun getHighlightingLexer(): Lexer {
-        return RustLexer();
+
+    override fun getHighlightingLexer() = RustLexer()
+
+    override fun getTokenHighlights(tokenType: IElementType?) = pack(map(tokenType))
+
+    private fun map(tokenType: IElementType?) = when (tokenType) {
+        is RustKeywordTokenType -> RustColors.KEYWORD
+
+        IDENTIFIER -> RustColors.IDENTIFIER
+
+        LIFETIME -> RustColors.LIFETIME
+        STATIC_LIFETIME -> RustColors.LIFETIME
+
+        CHAR_LITERAL -> RustColors.CHAR
+        BYTE_LITERAL -> RustColors.CHAR
+        STRING_LITERAL -> RustColors.STRING
+        BYTE_STRING_LITERAL -> RustColors.STRING
+        INTEGER_LITERAL -> RustColors.NUMBER
+        FLOAT_LITERAL -> RustColors.NUMBER
+
+        BLOCK_COMMENT -> RustColors.BLOCK_COMMENT
+        EOL_COMMENT -> RustColors.EOL_COMMENT
+
+        INNER_DOC_COMMENT -> RustColors.DOC_COMMENT
+        OUTER_DOC_COMMENT -> RustColors.DOC_COMMENT
+
+        LPAREN, RPAREN -> RustColors.PARENTHESIS
+        LBRACE, RBRACE -> RustColors.BRACES
+        LBRACK, RBRACK -> RustColors.BRACKETS
+
+        SEMICOLON -> RustColors.SEMICOLON
+        DOT -> RustColors.DOT
+        COMMA -> RustColors.COMMA
+
+        else -> null
     }
-
-    override fun getTokenHighlights(tokenType: IElementType?): Array<out TextAttributesKey> {
-        return SyntaxHighlighterBase.pack(map(tokenType))
-    }
-
-    private fun map(tokenType: IElementType?): TextAttributesKey? {
-        return when (tokenType) {
-            is RustKeywordTokenType -> RustColors.KEYWORD
-
-            IDENTIFIER -> RustColors.IDENTIFIER
-
-            LIFETIME -> RustColors.LIFETIME
-            STATIC_LIFETIME -> RustColors.LIFETIME
-
-            CHAR_LITERAL -> RustColors.CHAR
-            BYTE_LITERAL -> RustColors.CHAR
-            STRING_LITERAL -> RustColors.STRING
-            BYTE_STRING_LITERAL -> RustColors.STRING
-            INTEGER_LITERAL -> RustColors.NUMBER
-            FLOAT_LITERAL -> RustColors.NUMBER
-
-            BLOCK_COMMENT -> RustColors.BLOCK_COMMENT
-            EOL_COMMENT -> RustColors.EOL_COMMENT
-
-            INNER_DOC_COMMENT -> RustColors.DOC_COMMENT
-            OUTER_DOC_COMMENT -> RustColors.DOC_COMMENT
-
-            LPAREN, RPAREN -> RustColors.PARENTHESIS
-            LBRACE, RBRACE -> RustColors.BRACES
-            LBRACK, RBRACK -> RustColors.BRACKETS
-
-            SEMICOLON -> RustColors.SEMICOLON
-            DOT -> RustColors.DOT
-            COMMA -> RustColors.COMMA
-
-            else -> null
-        }
-    }
-
 }

--- a/src/org/rust/lang/highlight/RustHighlighter.kt
+++ b/src/org/rust/lang/highlight/RustHighlighter.kt
@@ -19,9 +19,8 @@ public class RustHighlighter : SyntaxHighlighterBase() {
     }
 
     private fun map(tokenType: IElementType?): TextAttributesKey? {
-        return if (tokenType is RustKeywordTokenType)
-            RustColors.KEYWORD
-        else when (tokenType) {
+        return when (tokenType) {
+            is RustKeywordTokenType -> RustColors.KEYWORD
 
             IDENTIFIER -> RustColors.IDENTIFIER
 


### PR DESCRIPTION
This PR simplifies the code in the `RustHighlighter` class by using the expression body syntax and merging two `if` and `when` blocks