### PR TITLE
.editorconfig: Do not trim trailing whitespace in Rust files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.rs]
+trim_trailing_whitespace = false
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
We would normally want this, but since whitespace can be important for some tests it doesn't make any sense here.