### PR TITLE
Colorscheme: manually annotate highlighter demo text

### DIFF
--- a/resources/org/rust/lang/colorscheme/highlighterDemoText.rs
+++ b/resources/org/rust/lang/colorscheme/highlighterDemoText.rs
@@ -4,18 +4,18 @@ fn main() {
     // `*` or `/` means multiply or divide by 2
 
     let program = "+ + * - /";
-    let mut accumulator = 0;
+    let mut <mut-binding>accumulator</mut-binding> = 0;
 
     for token in program.chars() {
         match token {
-            '+' => accumulator += 1,
-            '-' => accumulator -= 1,
-            '*' => accumulator *= 2,
-            '/' => accumulator /= 2,
+            '+' => <mut-binding>accumulator</mut-binding> += 1,
+            '-' => <mut-binding>accumulator</mut-binding> -= 1,
+            '*' => <mut-binding>accumulator</mut-binding> *= 2,
+            '/' => <mut-binding>accumulator</mut-binding> /= 2,
             _ => { /* ignore everything else */ }
         }
     }
 
-    println!("The program \"{}\" calculates the value {}",
-              program, accumulator);
+    <macro>println!</macro>("The program \"{}\" calculates the value {}",
+             program, <mut-binding>accumulator</mut-binding>);
 }

--- a/src/org/rust/lang/colorscheme/RustColorSettingsPage.kt
+++ b/src/org/rust/lang/colorscheme/RustColorSettingsPage.kt
@@ -32,7 +32,13 @@ public class RustColorSettingsPage : ColorSettingsPage {
             d("Type Parameter", RustColors.TYPE_PARAMETER),
             d("Mutable binding", RustColors.MUT_BINDING)
     )
-    private val TAGS = emptyMap<String, TextAttributesKey>()
+    // This tags should be kept in sync with RustAnnotator highlighting logic
+    private val ANNOTATOR_TAGS = mapOf(
+        "attribute" to RustColors.ATTRIBUTE,
+        "macro" to RustColors.MACRO,
+        "type-parameter" to RustColors.TYPE_PARAMETER,
+        "mut-binding" to RustColors.MUT_BINDING
+    )
     private val DEMO_TEXT by lazy {
         val stream = javaClass.classLoader.getResourceAsStream("org/rust/lang/colorscheme/highlighterDemoText.rs")
         StreamUtil.readText(stream, "UTF-8")
@@ -43,6 +49,6 @@ public class RustColorSettingsPage : ColorSettingsPage {
     override fun getAttributeDescriptors() = ATTRS
     override fun getColorDescriptors() = ColorDescriptor.EMPTY_ARRAY
     override fun getHighlighter() = RustHighlighter()
-    override fun getAdditionalHighlightingTagToDescriptorMap() = TAGS
+    override fun getAdditionalHighlightingTagToDescriptorMap() = ANNOTATOR_TAGS
     override fun getDemoText() = DEMO_TEXT
 }


### PR DESCRIPTION
I am somewhat unsure of whether the manual annotating (which needs to be kept in sync with the actual annotator) is the best approach here, but it seems to work.

See #114.