### PR TITLE
(MISC): add Rust live templates

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -10,10 +10,13 @@ Please note that most of the features are missing at the moment.
   want.
 
 
-Semantic features already implemented:
+## Features
 
 * `Go to definition` for local variables,
 * `File structure`, aka imenu. `Ctrl-F12` and `Alt-7` by default,
 * `Expand selection` bound to `Ctrl-w` by default.
+* `Live templates` aka snippets (`Ctrl-j` by default).
+
+## Editors
 
 We also have guides for [Emacs](Emacs.md) and [Vim](Vim.md) users :)

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -98,6 +98,9 @@
         <localInspection language="RUST" enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.lang.inspections.ApproxConstantInspection"/>
 
+        <!-- Live Templates -->
+        <defaultLiveTemplatesProvider implementation="org.rust.lang.template.RustLiveTemplatesProvider"/>
+        <liveTemplateContext implementation="org.rust.lang.template.RustFileContextType"/>
 
         <!-- Toml -->
 

--- a/resources/org/rust/lang/liveTemplates/Rust.xml
+++ b/resources/org/rust/lang/liveTemplates/Rust.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<templateSet group="Rust">
+    <template name="p" description="print" toReformat="true" toShortenFQNames="true"
+              value="println!(&quot;$END$&quot;);">
+
+        <context>
+            <option name="RUST_FILE" value="true"/>
+        </context>
+    </template>
+
+    <template name="pd" description="debug print" toReformat="true" toShortenFQNames="true"
+              value="println!(&quot;{:?}&quot;, $END$);">
+
+        <context>
+            <option name="RUST_FILE" value="true"/>
+        </context>
+    </template>
+
+    <template name="ppd" description="debug pretty print" toReformat="true" toShortenFQNames="true"
+              value="println!(&quot;{:#?}&quot;, $END$);">
+
+        <context>
+            <option name="RUST_FILE" value="true"/>
+        </context>
+    </template>
+</templateSet>

--- a/src/org/rust/lang/template/RustFileContextType.kt
+++ b/src/org/rust/lang/template/RustFileContextType.kt
@@ -1,0 +1,12 @@
+package org.rust.lang.template
+
+import com.intellij.codeInsight.template.TemplateContextType
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiUtilCore
+import org.rust.lang.RustLanguage
+
+
+class RustFileContextType : TemplateContextType("RUST_FILE", "Rust file") {
+    override fun isInContext(file: PsiFile, offset: Int): Boolean =
+        PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(RustLanguage.INSTANCE)
+}

--- a/src/org/rust/lang/template/RustLiveTemplatesProvider.kt
+++ b/src/org/rust/lang/template/RustLiveTemplatesProvider.kt
@@ -1,0 +1,11 @@
+package org.rust.lang.template
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider
+
+class RustLiveTemplatesProvider : DefaultLiveTemplatesProvider{
+    override fun getDefaultLiveTemplateFiles(): Array<out String>? {
+        return arrayOf("/org/rust/lang/liveTemplates/Rust")
+    }
+
+    override fun getHiddenLiveTemplateFiles(): Array<out String>? = null
+}


### PR DESCRIPTION
@atsky please review.

This adds a `Rust file` template context, so the user can create her own snippets for Rust. 

This also adds two snippets for printing `p -> println!("")` and for printing a debug representation of value `pd -> println!("{:#?}", )`. The last one is nice, because nobody remembers the cryptic `:#?`syntax for debug pretty printing.