### PR TITLE
Gradle: Fix name collision in IntelliJ plugin configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - oraclejdk8
 
-env: ORG_GRADLE_PROJECT_DOWNLOAD_SOURCES=false
+env: ORG_GRADLE_PROJECT_downloadIdeaSources=false

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ intellij {
     pluginName 'IntelliJ Rust'
 
     version ideaVersion
-    downloadSources Boolean.valueOf(downloadSources)
+    downloadSources Boolean.valueOf(downloadIdeaSources)
 
     sandboxDirectory project.rootDir.canonicalPath + "/.sandbox"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ version = 0.0.1
 
 buildNumber = SNAPSHOT
 
-downloadSources = true
+downloadIdeaSources = true


### PR DESCRIPTION
`downloadSources Boolean.valueOf(downloadSources)` was essentially a no-op introduced by 0d055fd