### PR TITLE
(RES): implement child modules resolve

### DIFF
--- a/src/org/rust/lang/core/grammar/rust.bnf
+++ b/src/org/rust/lang/core/grammar/rust.bnf
@@ -292,6 +292,7 @@ private stmt_item_group ::= static_item
 private block_item_group ::= &(UNSAFE? FN   ) fn_item
                            | &(UNSAFE? TRAIT) trait_item
                            | &(UNSAFE? IMPL ) impl_item
+                           | mod_decl_item
                            | mod_item
                            | foreign_mod_item
                            | struct_item
@@ -465,7 +466,9 @@ private crate_name ::= IDENTIFIER [ AS IDENTIFIER ]
 // Struct & Enum
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-mod_item ::= MOD IDENTIFIER (SEMICOLON | LBRACE inner_attrs? item * RBRACE) {
+mod_decl_item ::= MOD IDENTIFIER SEMICOLON
+
+mod_item ::= MOD IDENTIFIER LBRACE inner_attrs? item * RBRACE {
   pin(".*") = 1
 }
 

--- a/src/org/rust/lang/core/psi/util/RustModExtensions.kt
+++ b/src/org/rust/lang/core/psi/util/RustModExtensions.kt
@@ -5,6 +5,8 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RustModItem
 
 
+val MOD_RS = "mod.rs"
+
 private val RustModItem.modDir: PsiDirectory?
     get() {
         val parent = containingMod ?: return containingFile.parent
@@ -21,7 +23,7 @@ private val RustModItem.isCrateRoot: Boolean
 
 private val RustModItem.ownsDirectory: Boolean
     get() = containingMod != null || // any inline nested module owns a directory
-        containingFile.name == "mod.rs" ||
+        containingFile.name == MOD_RS ||
         isCrateRoot
 
 
@@ -40,7 +42,7 @@ fun RustModItem.submoduleFile(modName: String): ChildModFile {
     }
 
     val dir = modDir
-    val dirMod = dir?.findSubdirectory(modName)?.findFile("mod.rs")
+    val dirMod = dir?.findSubdirectory(modName)?.findFile(MOD_RS)
     val fileMod = dir?.findFile("$modName.rs")
 
     val variants = listOf(fileMod, dirMod).filterNotNull()

--- a/src/org/rust/lang/core/psi/util/RustModExtensions.kt
+++ b/src/org/rust/lang/core/psi/util/RustModExtensions.kt
@@ -1,0 +1,56 @@
+package org.rust.lang.core.psi.util
+
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RustModItem
+
+
+private val RustModItem.modDir: PsiDirectory?
+    get() {
+        val parent = containingMod ?: return containingFile.parent
+
+        val name = this.name ?: return null
+
+        return parent.modDir?.findSubdirectory(name)
+    }
+
+
+private val RustModItem.isCrateRoot: Boolean
+    get() = containingMod == null &&
+        (containingFile.name == "main.rs" || containingFile.name == "lib.rs")
+
+private val RustModItem.ownsDirectory: Boolean
+    get() = containingMod != null || // any inline nested module owns a directory
+        containingFile.name == "mod.rs" ||
+        isCrateRoot
+
+
+sealed class ChildModFile {
+    val mod: RustModItem?
+        get() = (this as? Found)?.file?.firstChild as? RustModItem
+
+    class NotFound : ChildModFile()
+    class Found(val file: PsiFile) : ChildModFile()
+    class Ambigious(val paths: Collection<PsiFile>) : ChildModFile()
+}
+
+fun RustModItem.submoduleFile(modName: String): ChildModFile {
+    if (!ownsDirectory) {
+        return ChildModFile.NotFound()
+    }
+
+    val dir = modDir
+    val dirMod = dir?.findSubdirectory(modName)?.findFile("mod.rs")
+    val fileMod = dir?.findFile("$modName.rs")
+
+    val variants = listOf(fileMod, dirMod).filterNotNull()
+
+    when (variants.size) {
+        0 -> return ChildModFile.NotFound()
+        2 -> return ChildModFile.Ambigious(variants)
+    }
+
+    return ChildModFile.Found(variants.first())
+}
+
+

--- a/src/org/rust/lang/core/psi/util/RustPsiExtensions.kt
+++ b/src/org/rust/lang/core/psi/util/RustPsiExtensions.kt
@@ -10,6 +10,18 @@ import org.rust.lang.core.psi.*
 // Extension points
 //
 
+inline fun <reified T : PsiElement> PsiElement.parentOfType(): T? {
+    var current = parent
+    while (current != null) {
+        when (current) {
+            is T -> return current
+            else -> current = current.parent
+        }
+    }
+    return null
+}
+
+
 fun PsiElement?.getNextNonPhantomSibling(): PsiElement? =
     this?.let {
         val next = it.nextSibling
@@ -49,3 +61,6 @@ fun RustItem.isPublic() = vis != null
 
 val RustPatBinding.isMut: Boolean
     get()  = bindingMode?.mut != null
+
+val RustCompositeElement.containingMod: RustModItem?
+    get() = parentOfType<RustModItem>()

--- a/src/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -4,6 +4,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.util.isBefore
+import org.rust.lang.core.psi.util.containingMod
+import org.rust.lang.core.psi.util.submoduleFile
 import org.rust.lang.core.resolve.scope.RustResolveScope
 import org.rust.lang.core.resolve.scope.resolveWith
 import org.rust.lang.core.resolve.util.RustResolveUtil
@@ -84,6 +86,16 @@ public class RustResolveEngine() {
 
         private fun found(elem: RustNamedElement) {
             matched = elem
+
+            if (elem is RustModDeclItem) {
+                val mod = elem.containingMod ?: return
+                val name = elem.name ?: return
+                val submod = mod.submoduleFile(name).mod
+                if (submod != null) {
+                    matched = submod
+                }
+            }
+
         }
 
         private fun match(elem: RustNamedElement): Boolean =

--- a/src/org/rust/lang/intentions/ExpandModule.kt
+++ b/src/org/rust/lang/intentions/ExpandModule.kt
@@ -8,21 +8,21 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.file.PsiFileImplUtil
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
 import org.rust.lang.core.psi.impl.RustFileImpl
+import org.rust.lang.core.psi.util.MOD_RS
 
 class ExpandModule : IntentionAction {
-    private val MOD_FILE_NAME = "mod.rs"
 
     override fun getFamilyName() = "Expand module structure"
     override fun startInWriteAction() = true
     override fun getText() = "Expand Module"
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?) =
-        file is RustFileImpl && file.name != MOD_FILE_NAME
+        file is RustFileImpl && file.name != MOD_RS
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         file ?: return
         val dirName = FileUtil.getNameWithoutExtension(file.name)
         val directory = file.parent?.createSubdirectory(dirName)
         MoveFilesOrDirectoriesUtil.doMoveFile(file, directory)
-        PsiFileImplUtil.setName(file, MOD_FILE_NAME)
+        PsiFileImplUtil.setName(file, MOD_RS)
     }
 }

--- a/test/org/rust/lang/core/resolve/RustProjResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustProjResolveTestCase.kt
@@ -1,0 +1,22 @@
+package org.rust.lang.core.resolve
+
+import org.assertj.core.api.Assertions.assertThat
+import org.rust.lang.RustTestCase
+import org.rust.lang.core.resolve.ref.RustReference
+
+
+class RustProjResolveTestCase : RustTestCase() {
+    override fun getTestDataPath() = "testData/org/rust/lang/core/resolve/fixtures"
+
+    private fun doTest(crateRoot: String, mod: String) {
+        myFixture.configureByFiles(crateRoot, mod)
+
+        val usage = file.findReferenceAt(myFixture.caretOffset)!! as RustReference
+        val declaration = usage.resolve()
+
+        assertThat(declaration).isNotNull()
+    }
+
+    fun testChildMod() = doTest("child_mod/main.rs", "child_mod/child.rs")
+    fun testNestedChildMod() = doTest("nested_child_mod/main.rs", "nested_child_mod/inner/child.rs")
+}

--- a/testData/org/rust/lang/core/resolve/fixtures/child_mod/child.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/child_mod/child.rs
@@ -1,0 +1,2 @@
+fn foo() {}
+fn bar() {}

--- a/testData/org/rust/lang/core/resolve/fixtures/child_mod/main.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/child_mod/main.rs
@@ -1,0 +1,5 @@
+mod child;
+
+fn main() {
+    child::<caret>foo();
+}

--- a/testData/org/rust/lang/core/resolve/fixtures/nested_child_mod/inner/child.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/nested_child_mod/inner/child.rs
@@ -1,0 +1,2 @@
+fn foo() {}
+fn bar() {}

--- a/testData/org/rust/lang/core/resolve/fixtures/nested_child_mod/main.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/nested_child_mod/main.rs
@@ -1,0 +1,7 @@
+mod inner {
+    pub mod child;
+}
+
+fn main() {
+    inner::child::<caret>foo();
+}


### PR DESCRIPTION
When we see `mod foo;` we should try to find a file corresponding to
`foo`. It is possible only if a parent module is a directory owner.

A module is a directory owner if it is either
  * a crate root
  * a nested inline module
  * called `mod.rs`

It is an error to have `mod foo;` in a non directory owning module.

The file name for `foo` is (modulo #[path = ] attribute) a directory
name of the parent module plus either `/foo.rs` or `/foo/mod.rs`.

Example 1

```Rust
// file src/main.rs, a crate root

mod foo; // src/foo.rs

mod inner {
    mod foo; // src/inner/foo.rs
}
```

Example 2

```Rust
// file src/foo.rs

mod bar; // forbidden

mod inner {
    mod foo; // src/inner/foo.rs
}
```

The semantics of `mod foo;` nested inside a function is not fully
specified at the moment: https://github.com/rust-lang/rust/issues/29765

@atsky @alexeykudinkin please review