### PR TITLE
(RES): fix resolve of `let x = x`

### DIFF
--- a/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
@@ -27,6 +27,8 @@ class RustResolveTestCase : RustTestCase() {
     fun testModItems() = checkIsBound()
     fun testCrateItems() = checkIsBound()
     fun testNestedModule() = checkIsBound(atOffset = 48)
+    fun testLetCycle2() = checkIsBound(atOffset = 20)
+    fun testLetCycle1() = checkIsUnbound()
     fun testUnbound() = checkIsUnbound()
     fun testOrdering() = checkIsUnbound()
     fun testModBoundary() = checkIsUnbound()

--- a/testData/org/rust/lang/core/resolve/fixtures/let_cycle1.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/let_cycle1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x = {
+        <caret>x
+    };
+}

--- a/testData/org/rust/lang/core/resolve/fixtures/let_cycle2.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/let_cycle2.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let x = 92;
+    let x = <caret>x;
+}


### PR DESCRIPTION
@atsky @alexeykudinkin please review.

This has O(n^2) behaviour for pathalogical cases like `let x = {let x = { let x = ...}}` but I guess it is OK.

