### PR TITLE
FindUsagesProvider: Return empty strings

### DIFF
--- a/src/org/rust/lang/search/RustFindUsagesProvider.kt
+++ b/src/org/rust/lang/search/RustFindUsagesProvider.kt
@@ -2,11 +2,7 @@ package org.rust.lang.search
 
 import com.intellij.lang.HelpID
 import com.intellij.lang.findUsages.FindUsagesProvider
-import com.intellij.psi.ElementDescriptionUtil
 import com.intellij.psi.PsiElement
-import com.intellij.usageView.UsageViewLongNameLocation
-import com.intellij.usageView.UsageViewNodeTextLocation
-import com.intellij.usageView.UsageViewTypeLocation
 import org.rust.lang.core.psi.RustPatBinding
 
 class RustFindUsagesProvider : FindUsagesProvider {
@@ -17,12 +13,7 @@ class RustFindUsagesProvider : FindUsagesProvider {
 
     override fun getHelpId(element: PsiElement) = HelpID.FIND_OTHER_USAGES
 
-    override fun getType(element: PsiElement) =
-        ElementDescriptionUtil.getElementDescription(element, UsageViewTypeLocation.INSTANCE)
-
-    override fun getDescriptiveName(element: PsiElement) =
-        ElementDescriptionUtil.getElementDescription(element, UsageViewLongNameLocation.INSTANCE)
-
-    override fun getNodeText(element: PsiElement, useFullName: Boolean) =
-        ElementDescriptionUtil.getElementDescription(element, UsageViewNodeTextLocation.INSTANCE)
+    override fun getType(element: PsiElement) = ""
+    override fun getDescriptiveName(element: PsiElement) = ""
+    override fun getNodeText(element: PsiElement, useFullName: Boolean) = ""
 }


### PR DESCRIPTION
Returning an empty string here will automatically ask the DescriptionProvider, but should prevent the infinite recursion that could happen before.

Resolves #139 