### PR TITLE
(INF): change Language to object instead of a class

### DIFF
--- a/src/org/rust/lang/RustFileType.kt
+++ b/src/org/rust/lang/RustFileType.kt
@@ -5,9 +5,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
-public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
-
-    public object INSTANCE : RustFileType() {}
+object RustFileType : LanguageFileType(RustLanguage) {
 
     public object DEFAULTS {
         public val EXTENSION: String = "rs";
@@ -25,6 +23,5 @@ public open class RustFileType : LanguageFileType(RustLanguage.INSTANCE) {
     override fun getDescription(): String {
         return "Rust Files"
     }
-
 }
 

--- a/src/org/rust/lang/RustFileTypeFactory.kt
+++ b/src/org/rust/lang/RustFileTypeFactory.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.fileTypes.FileTypeFactory
 public class RustFileTypeFactory : FileTypeFactory() {
 
     override fun createFileTypes(consumer: FileTypeConsumer) {
-        consumer.consume(RustFileType.INSTANCE, RustFileType.DEFAULTS.EXTENSION);
+        consumer.consume(RustFileType, RustFileType.DEFAULTS.EXTENSION);
     }
 
 }

--- a/src/org/rust/lang/RustLanguage.kt
+++ b/src/org/rust/lang/RustLanguage.kt
@@ -2,11 +2,7 @@ package org.rust.lang
 
 import com.intellij.lang.Language
 
-public open class RustLanguage : Language("RUST") {
-
-    // XXX: can't use companion object here because companions are loaded lazily
-    object INSTANCE : RustLanguage() {}
-
+object RustLanguage : Language("RUST") {
     override fun isCaseSensitive() = true
 }
 

--- a/src/org/rust/lang/codestyle/RustCodeStyleSettingsProvider.kt
+++ b/src/org/rust/lang/codestyle/RustCodeStyleSettingsProvider.kt
@@ -21,7 +21,7 @@ class RustCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
     }
 
     private class RustCodeStyleMainPanel(currentSettings: CodeStyleSettings, settings: CodeStyleSettings) :
-            TabbedLanguageCodeStylePanel(RustLanguage.INSTANCE, currentSettings, settings) {
+            TabbedLanguageCodeStylePanel(RustLanguage, currentSettings, settings) {
 
         override fun initTabs(settings: CodeStyleSettings?) {
             addWrappingAndBracesTab(settings)

--- a/src/org/rust/lang/codestyle/RustLanguageCodeStyleSettingsProvider.kt
+++ b/src/org/rust/lang/codestyle/RustLanguageCodeStyleSettingsProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import org.rust.lang.RustLanguage
 
 class RustLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
-    override fun getLanguage() = RustLanguage.INSTANCE
+    override fun getLanguage() = RustLanguage
 
     override fun customizeSettings(consumer: CodeStyleSettingsCustomizable,
                                    settingsType: LanguageCodeStyleSettingsProvider.SettingsType) {

--- a/src/org/rust/lang/core/RustParserDefinition.kt
+++ b/src/org/rust/lang/core/RustParserDefinition.kt
@@ -21,7 +21,7 @@ import org.rust.lang.core.psi.impl.RustFileImpl
 
 public class RustParserDefinition : ParserDefinition {
 
-    val RUST_FILE_TYPE: IFileElementType = IFileElementType(RustLanguage.INSTANCE)
+    val RUST_FILE_TYPE: IFileElementType = IFileElementType(RustLanguage)
 
     override fun createFile(viewProvider: FileViewProvider): PsiFile? =
         RustFileImpl(viewProvider)

--- a/src/org/rust/lang/core/lexer/RustTokenType.kt
+++ b/src/org/rust/lang/core/lexer/RustTokenType.kt
@@ -3,6 +3,6 @@ package org.rust.lang.core.lexer
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.RustLanguage
 
-public open class RustTokenType(val s: String) : IElementType(s, RustLanguage.INSTANCE) {
+public open class RustTokenType(val s: String) : IElementType(s, RustLanguage) {
 
 }

--- a/src/org/rust/lang/core/psi/RustCompositeElementType.kt
+++ b/src/org/rust/lang/core/psi/RustCompositeElementType.kt
@@ -3,4 +3,4 @@ package org.rust.lang.core.psi
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.RustLanguage
 
-public class RustCompositeElementType(s: String) : IElementType(s, RustLanguage.INSTANCE) {}
+public class RustCompositeElementType(s: String) : IElementType(s, RustLanguage) {}

--- a/src/org/rust/lang/core/psi/impl/RustFileImpl.kt
+++ b/src/org/rust/lang/core/psi/impl/RustFileImpl.kt
@@ -6,8 +6,8 @@ import com.intellij.psi.FileViewProvider
 import org.rust.lang.RustFileType
 import org.rust.lang.RustLanguage
 
-public class RustFileImpl(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvider, RustLanguage.INSTANCE) {
+public class RustFileImpl(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvider, RustLanguage) {
 
-    override fun getFileType(): FileType = RustFileType.INSTANCE;
+    override fun getFileType(): FileType = RustFileType;
 
 }

--- a/src/org/rust/lang/module/RustModuleBuilder.kt
+++ b/src/org/rust/lang/module/RustModuleBuilder.kt
@@ -29,7 +29,7 @@ public class RustModuleBuilder() : ModuleBuilder() {
         moduleType.createWizardSteps(wizardContext, this, modulesProvider)
 
     override fun getModuleType(): RustModuleType {
-        return RustModuleType.INSTANCE
+        return RustModuleType
     }
 
     override fun setupRootModel(rootModel: ModifiableRootModel?) {

--- a/src/org/rust/lang/module/RustModuleType.kt
+++ b/src/org/rust/lang/module/RustModuleType.kt
@@ -5,7 +5,7 @@ import org.rust.lang.icons.RustIcons
 import javax.swing.Icon
 
 
-public class RustModuleType() : ModuleType<RustModuleBuilder>(RustModuleType.RUST_MODULE) {
+object RustModuleType : ModuleType<RustModuleBuilder>("RUST_MODULE") {
 
     override fun createModuleBuilder(): RustModuleBuilder {
         return RustModuleBuilder()
@@ -25,10 +25,5 @@ public class RustModuleType() : ModuleType<RustModuleBuilder>(RustModuleType.RUS
 
     override fun getNodeIcon(isOpened: Boolean): Icon {
         return RustIcons.FILE
-    }
-
-    companion object {
-        public val RUST_MODULE: String = "RUST_MODULE"
-        public val INSTANCE: RustModuleType = RustModuleType()
     }
 }

--- a/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
+++ b/src/org/rust/lang/spellchecker/RustSpellcheckingStrategy.kt
@@ -9,7 +9,7 @@ import org.rust.lang.core.lexer.RustTokenElementTypes.STRING_LITERAL
 class RustSpellcheckingStrategy : SpellcheckingStrategy() {
     private val stringLiteralTokenizer = StringLiteralTokenizer()
 
-    override fun isMyContext(element: PsiElement) = RustLanguage.INSTANCE.`is`(element.language)
+    override fun isMyContext(element: PsiElement) = RustLanguage.`is`(element.language)
 
     override fun getTokenizer(element: PsiElement?): Tokenizer<*> {
         if (element?.node?.elementType == STRING_LITERAL) {

--- a/src/org/rust/lang/template/RustFileContextType.kt
+++ b/src/org/rust/lang/template/RustFileContextType.kt
@@ -8,5 +8,5 @@ import org.rust.lang.RustLanguage
 
 class RustFileContextType : TemplateContextType("RUST_FILE", "Rust file") {
     override fun isInContext(file: PsiFile, offset: Int): Boolean =
-        PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(RustLanguage.INSTANCE)
+        PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(RustLanguage)
 }

--- a/src/org/toml/lang/TomlFileType.kt
+++ b/src/org/toml/lang/TomlFileType.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.vfs.VirtualFile
 import org.toml.lang.icons.TomlIcons
 
-public class TomlFileType : LanguageFileType(TomlLanguage.INSTANCE) {
+object  TomlFileType : LanguageFileType(TomlLanguage) {
     public object DEFAULTS {
         val EXTENSION = "toml";
         val DESCRIPTION = "TOML file";
@@ -15,8 +15,4 @@ public class TomlFileType : LanguageFileType(TomlLanguage.INSTANCE) {
     override fun getDefaultExtension() = DEFAULTS.EXTENSION
     override fun getIcon() = TomlIcons.FILE
     override fun getCharset(file: VirtualFile, content: ByteArray) = "UTF-8"
-
-    companion object {
-        public val INSTANCE: TomlFileType = TomlFileType()
-    }
 }

--- a/src/org/toml/lang/TomlFileTypeFactory.kt
+++ b/src/org/toml/lang/TomlFileTypeFactory.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.fileTypes.FileTypeFactory
 
 public class TomlFileTypeFactory : FileTypeFactory() {
     override fun createFileTypes(consumer: FileTypeConsumer) {
-        consumer.consume(TomlFileType.INSTANCE,
+        consumer.consume(TomlFileType,
                 ExactFileNameMatcher("Cargo.lock"),
                 ExtensionFileNameMatcher(TomlFileType.DEFAULTS.EXTENSION))
     }

--- a/src/org/toml/lang/TomlLanguage.kt
+++ b/src/org/toml/lang/TomlLanguage.kt
@@ -2,10 +2,6 @@ package org.toml.lang
 
 import com.intellij.lang.Language
 
-
-open public class TomlLanguage : Language("TOML", "text/toml") {
-    // XXX: can't use companion object here because companions are loaded lazily
-    public object INSTANCE : TomlLanguage() {}
-
+object TomlLanguage : Language("TOML", "text/toml") {
     override fun isCaseSensitive() = true
 }

--- a/src/org/toml/lang/core/lexer/TomlTokenType.kt
+++ b/src/org/toml/lang/core/lexer/TomlTokenType.kt
@@ -4,4 +4,4 @@ import com.intellij.psi.tree.IElementType
 import org.toml.lang.TomlLanguage
 
 
-public class TomlTokenType(debugName: String) : IElementType(debugName, TomlLanguage.INSTANCE)
+public class TomlTokenType(debugName: String) : IElementType(debugName, TomlLanguage)

--- a/src/org/toml/lang/core/parser/TomlParserDefinition.kt
+++ b/src/org/toml/lang/core/parser/TomlParserDefinition.kt
@@ -47,7 +47,7 @@ public class TomlParserDefinition : ParserDefinition {
             TomlTypes.Factory.createElement(node)
 
     companion object {
-        val FILE: IFileElementType = IFileElementType(TomlLanguage.INSTANCE)
+        val FILE: IFileElementType = IFileElementType(TomlLanguage)
         val WHITE_SPACES: TokenSet = TokenSet.create(TokenType.WHITE_SPACE);
         val COMMENTS: TokenSet = TokenSet.create(TomlTypes.COMMENT);
     }

--- a/src/org/toml/lang/core/psi/TomlElementType.kt
+++ b/src/org/toml/lang/core/psi/TomlElementType.kt
@@ -3,6 +3,6 @@ package org.toml.lang.core.psi
 import com.intellij.psi.tree.IElementType
 import org.toml.lang.TomlLanguage
 
-class TomlElementType(debugName: String) : IElementType(debugName, TomlLanguage.INSTANCE) {
+class TomlElementType(debugName: String) : IElementType(debugName, TomlLanguage) {
 
 }

--- a/src/org/toml/lang/core/psi/TomlFile.kt
+++ b/src/org/toml/lang/core/psi/TomlFile.kt
@@ -6,9 +6,9 @@ import com.intellij.psi.FileViewProvider
 import org.toml.lang.TomlFileType
 import org.toml.lang.TomlLanguage
 
-class TomlFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, TomlLanguage.INSTANCE) {
+class TomlFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, TomlLanguage) {
     override fun getFileType(): FileType =
-            TomlFileType.INSTANCE
+            TomlFileType
 
     override fun toString(): String =
             "TOML File"

--- a/test/org/rust/lang/core/parser/RustParsingTestCaseBase.kt
+++ b/test/org/rust/lang/core/parser/RustParsingTestCaseBase.kt
@@ -39,7 +39,7 @@ abstract class RustParsingTestCaseBase(@NonNls dataPath: String)
 
     override fun setUp() {
         super.setUp()
-        addExplicitExtension(LanguageBraceMatching.INSTANCE, RustLanguage.INSTANCE, RustBraceMatcher())
+        addExplicitExtension(LanguageBraceMatching.INSTANCE, RustLanguage, RustBraceMatcher())
     }
 
     override fun tearDown() {


### PR DESCRIPTION
This removes *classes* RustLanguage and TomlLanguage and uses objects instead. 

See https://github.com/alexeykudinkin/intellij-rust/issues/144 and https://github.com/alexeykudinkin/intellij-rust/commit/c35874d618d732d39de5558b6842330e65d1f7c3 for motivation. 

@alexeykudinkin @atsky if it is OK, I would like to refactor FileTypes in a similar manner. 