### PR TITLE
Implement nonexistent module declaration inspection.

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -16,6 +16,10 @@ Please note that most of the features are missing at the moment.
 * `File structure`, aka imenu. `Ctrl-F12` and `Alt-7` by default,
 * `Expand selection` bound to `Ctrl-w` by default.
 * `Live templates` aka snippets (`Ctrl-j` by default).
+* `Expand module` intention helps you switch file based module to 
+  directory module structure.
+* `Nonexistent module declaration` inspection and corresponding 
+  quick fix facilitates you creating file based module for specified module name.
 
 ## Editors
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -109,6 +109,9 @@
         <localInspection language="RUST" enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.lang.inspections.SelfConventionInspection"/>
 
+        <localInspection language="RUST" enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.lang.inspections.NonexistentModuleDeclarationInspection"/>
+
         <!-- Live Templates -->
         <defaultLiveTemplatesProvider implementation="org.rust.lang.template.RustLiveTemplatesProvider"/>
         <liveTemplateContext implementation="org.rust.lang.template.RustFileContextType"/>

--- a/resources/inspectionDescriptions/NonexistentModuleDeclaration.html
+++ b/resources/inspectionDescriptions/NonexistentModuleDeclaration.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+You have neither file based nor directory based module with specified name. <br>
+You can apply quick fix to create corresponding file based module. <br>
+Then you can use 'Expand module' intention to go to directory based module structure.
+</body>
+</html>

--- a/src/org/rust/lang/inspections/NonexistentModuleDeclarationInspection.kt
+++ b/src/org/rust/lang/inspections/NonexistentModuleDeclarationInspection.kt
@@ -1,0 +1,38 @@
+package org.rust.lang.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFixBase
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.RustModDeclItem
+import org.rust.lang.core.psi.RustVisitor
+import org.rust.lang.core.psi.util.ChildModFile
+import org.rust.lang.core.psi.util.moduleFile
+
+class NonexistentModuleDeclarationInspection : LocalInspectionTool() {
+    val NONEXISTENT_MODULE_QUICKFIX = object: LocalQuickFixBase("Create module file") {
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val modFileName = "${descriptor.psiElement.text}.rs"
+            val modFile = descriptor.psiElement.containingFile.containingDirectory.createFile(modFileName)
+            FileEditorManager.getInstance(project).openFile(modFile.virtualFile, true)
+        }
+    }
+
+    override fun getGroupDisplayName() = "Rust"
+
+    override fun getDisplayName() = "Nonexistent module declaration"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object: RustVisitor() {
+            override fun visitModDeclItem(o: RustModDeclItem) {
+                if (o.moduleFile is ChildModFile.NotFound) {
+                    holder.registerProblem(o.identifier, "Nonexistent module declaration found. " +
+                        "Apply quick fix to create a module file.", NONEXISTENT_MODULE_QUICKFIX)
+                }
+            }
+        }
+    }
+}

--- a/test/org/rust/lang/inspections/RustInspectionsTest.kt
+++ b/test/org/rust/lang/inspections/RustInspectionsTest.kt
@@ -4,13 +4,23 @@ import com.intellij.codeInspection.LocalInspectionTool
 import org.rust.lang.RustTestCase
 
 class RustInspectionsTest : RustTestCase() {
+    val NONEXISTENT_MODULE_DECLARATION_HINT = "Create module file"
+
     override fun getTestDataPath() = "testData/org/rust/lang/inspections/fixtures"
 
     private inline  fun <reified T: LocalInspectionTool>doTest() {
         myFixture.enableInspections(T::class.java)
         myFixture.testHighlighting(true, false, true, fileName)
+
+    }
+
+    private inline  fun <reified T: LocalInspectionTool>doTestWithIntention(hint: String) {
+        doTest<T>()
+        myFixture.findSingleIntention(hint)
     }
 
     fun testApproxConstant() = doTest<ApproxConstantInspection>()
     fun testSelfConvention() = doTest<SelfConventionInspection>()
+    fun testNonexistentModuleDeclaration() =
+        doTestWithIntention<NonexistentModuleDeclarationInspection>(NONEXISTENT_MODULE_DECLARATION_HINT)
 }

--- a/testData/org/rust/lang/inspections/fixtures/nonexistent_module_declaration.rs
+++ b/testData/org/rust/lang/inspections/fixtures/nonexistent_module_declaration.rs
@@ -1,0 +1,5 @@
+mod <error>nonex<caret>istent</error>;
+
+fn main() {
+    println!("Hello, nonexistent module declaration inspection");
+}


### PR DESCRIPTION
Add inspection and appropriate test.
Register inspection as local inspection with error highlighting level.
Add extended inspection description.
Add some words about inspection under Features section in Usage.md.

Resolves #142