### PR TITLE
Implement getTextOffset properly for RustNamedElement

### DIFF
--- a/src/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
+++ b/src/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
@@ -20,4 +20,6 @@ public abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeEleme
     }
 
     override fun getNavigationElement() = getNameElement()
+
+    override fun getTextOffset(): Int = getNameElement()?.textOffset ?: super.getTextOffset()
 }

--- a/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
@@ -26,7 +26,7 @@ class RustResolveTestCase : RustTestCase() {
     fun testStructPatterns2() = checkIsBound()
     fun testModItems() = checkIsBound()
     fun testCrateItems() = checkIsBound()
-    fun testNestedModule() = checkIsBound(atOffset = 48)
+    fun testNestedModule() = checkIsBound(atOffset = 55)
     fun testLetCycle2() = checkIsBound(atOffset = 20)
     fun testLetCycle1() = checkIsUnbound()
     fun testUnbound() = checkIsUnbound()


### PR DESCRIPTION
The documentation for PsiElement.getTextOffset clearly states:

    Returns the offset in the file to which the caret should be placed
    when performing the navigation to the element. (For classes implementing
    PsiNamedElement, this should return the offset in the file of the
    name identifier.)

This condition did not hold w.r.t. RustNamedElement, causing issues such as #112.

The offset in nested module test case is updated accordingly.

Fixes #112.