### PR TITLE
(RES): resolve global paths

### DIFF
--- a/src/org/rust/lang/core/psi/impl/RustFileImpl.kt
+++ b/src/org/rust/lang/core/psi/impl/RustFileImpl.kt
@@ -5,9 +5,13 @@ import com.intellij.openapi.fileTypes.FileType
 import com.intellij.psi.FileViewProvider
 import org.rust.lang.RustFileType
 import org.rust.lang.RustLanguage
+import org.rust.lang.core.psi.RustModItem
 
 public class RustFileImpl(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvider, RustLanguage) {
 
-    override fun getFileType(): FileType = RustFileType;
+    override fun getFileType(): FileType = RustFileType
+
+    val mod: RustModItem?
+        get() = firstChild as? RustModItem
 
 }

--- a/src/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
+++ b/src/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
@@ -19,7 +19,7 @@ public abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeEleme
         throw UnsupportedOperationException();
     }
 
-    override fun getNavigationElement() = getNameElement()
+    override fun getNavigationElement(): PsiElement = getNameElement() ?: this
 
     override fun getTextOffset(): Int = getNameElement()?.textOffset ?: super.getTextOffset()
 }

--- a/src/org/rust/lang/core/psi/impl/mixin/RustPathPartImplMixin.kt
+++ b/src/org/rust/lang/core/psi/impl/mixin/RustPathPartImplMixin.kt
@@ -4,9 +4,10 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.lexer.RustTokenElementTypes
 import org.rust.lang.core.psi.RustPathPart
+import org.rust.lang.core.psi.RustQualifiedReferenceElement
+import org.rust.lang.core.psi.RustViewPath
 import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.resolve.ref.RustReference
-import org.rust.lang.core.psi.RustQualifiedReferenceElement
 import org.rust.lang.core.resolve.ref.RustReferenceImpl
 
 abstract class RustPathPartImplMixin(node: ASTNode) : RustNamedElementImpl(node)
@@ -24,6 +25,45 @@ abstract class RustPathPartImplMixin(node: ASTNode) : RustNamedElementImpl(node)
             if (it.firstChild != null) it else null
         }
 
+    private val isViewPath: Boolean
+        get() {
+            val parent = parent
+            return when (parent) {
+                is RustViewPath          -> true
+                is RustPathPartImplMixin -> parent.isViewPath
+                else                     -> false
+            }
+        }
+
+
+    /**
+     *  Returns `true` if this is a fully qualified path.
+     *
+     *  Paths in use items are special, they are implicitly FQ.
+     *
+     *  Example:
+     *
+     *    ```Rust
+     *    use ::foo::bar;   // FQ
+     *    use foo::bar;     // FQ, the same as the above
+     *
+     *    fn main() {
+     *        ::foo::bar;   // FQ
+     *        foo::bar;     // not FQ
+     *    }
+     *    ```
+     *
+     *  Reference:
+     *    https://doc.rust-lang.org/reference.html#paths
+     *    https://doc.rust-lang.org/reference.html#use-declarations
+     */
     override val isFullyQualified: Boolean
-        get() = getQualifier() == null && getSeparator() != null
+        get() {
+            val qual = getQualifier()
+            return if (qual == null) {
+                getSeparator() != null || (isViewPath && self == null && `super` == null)
+            } else {
+                qual.isFullyQualified
+            }
+        }
 }

--- a/src/org/rust/lang/core/psi/util/RustModExtensions.kt
+++ b/src/org/rust/lang/core/psi/util/RustModExtensions.kt
@@ -2,6 +2,7 @@ package org.rust.lang.core.psi.util
 
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.RustModDeclItem
 import org.rust.lang.core.psi.RustModItem
 
@@ -22,11 +23,13 @@ private val RustModItem.isCrateRoot: Boolean
     get() = containingMod == null &&
         (containingFile.name == "main.rs" || containingFile.name == "lib.rs")
 
-private val RustModItem.ownsDirectory: Boolean
+val RustModItem.ownsDirectory: Boolean
     get() = containingMod != null || // any inline nested module owns a directory
         containingFile.name == MOD_RS ||
         isCrateRoot
 
+val RustModItem.modDecls: Collection<RustModDeclItem>
+    get() = PsiTreeUtil.getChildrenOfTypeAsList(this, RustModDeclItem::class.java)
 
 sealed class ChildModFile {
     val mod: RustModItem?

--- a/src/org/rust/lang/core/psi/util/RustPsiExtensions.kt
+++ b/src/org/rust/lang/core/psi/util/RustPsiExtensions.kt
@@ -10,8 +10,8 @@ import org.rust.lang.core.psi.*
 // Extension points
 //
 
-inline fun <reified T : PsiElement> PsiElement.parentOfType(): T? {
-    var current = parent
+inline fun <reified T : PsiElement> PsiElement.parentOfType(strict: Boolean = true): T? {
+    var current = if (strict) parent else this
     while (current != null) {
         when (current) {
             is T -> return current

--- a/src/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -127,9 +127,11 @@ public class RustResolveEngine() {
         return ResolveResult.UNRESOLVED
     }
 
+
     private fun enumerateScopesFor(ref: RustQualifiedReferenceElement): Iterable<RustResolveScope> {
-        if (ref.isFullyQualified)
-            return listOf(RustResolveUtil.getGlobalResolveScopeFor(ref))
+        if (ref.isFullyQualified) {
+            return RustResolveUtil.getCrateRootFor(ref)?.let { listOf(it) } ?: emptyList()
+        }
 
         return object: Iterable<RustResolveScope> {
             override fun iterator(): Iterator<RustResolveScope> {

--- a/src/org/rust/lang/core/resolve/util/RustResolveUtil.kt
+++ b/src/org/rust/lang/core/resolve/util/RustResolveUtil.kt
@@ -1,6 +1,9 @@
 package org.rust.lang.core.resolve.util
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustModItem
+import org.rust.lang.core.psi.impl.RustFileImpl
+import org.rust.lang.core.psi.util.*
 import org.rust.lang.core.resolve.scope.RustResolveScope
 
 public object RustResolveUtil {
@@ -10,22 +13,73 @@ public object RustResolveUtil {
         while (current != null) {
             when (current) {
                 is RustResolveScope -> return current
-                else -> current = current.parent
+                else                -> current = current.parent
             }
         }
 
         return null
     }
 
-    fun getGlobalResolveScopeFor(elem: PsiElement): RustResolveScope {
-        var current = getResolveScopeFor(elem)
-        while (true)
-        {
-            val p = current?.let { getResolveScopeFor(it) } ?: break
-            current = p;
+    /**
+     *  Returns a "crate root": the top level module of the crate to which the `PsiElement` belongs.
+     *
+     *  In most cases it will be situated in another file, typically `src/main.rs` or `src/lib.rs`.
+     *
+     *  Reference:
+     *    https://doc.rust-lang.org/reference.html#crates-and-source-files
+     */
+    fun getCrateRootFor(elem: PsiElement): RustModItem? {
+        val mod = getSelfModFor(elem) ?: return null
+
+        val superMod = getSuperModFor(mod)
+        return if (superMod == null) mod else getCrateRootFor(superMod)
+    }
+
+    /**
+     *  Returns a parent module (`super::` in paths).
+     *
+     *  The parent module may be in the same or other file.
+     *
+     *  Reference:
+     *    https://doc.rust-lang.org/reference.html#paths
+     */
+    fun getSuperModFor(mod: RustModItem): RustModItem? {
+        val self = getSelfModFor(mod) ?: return null
+        val superInFile = self.containingMod
+        if (superInFile != null) {
+            return superInFile
         }
 
-        return current!!;
+        val file = self.containingFile
+        val dir = self.containingFile?.containingDirectory ?: return null
+        val dirOfParent = if (self.ownsDirectory) dir.parent else dir
+        dirOfParent?.files.orEmpty()
+            .filterIsInstance<RustFileImpl>()
+            .map { it.mod }
+            .filterNotNull()
+            .forEach { mod ->
+                for (declaration in mod.modDecls) {
+                    val childFile = declaration.moduleFile as? ChildModFile.Found ?: continue
+
+                    if (childFile.file == file ) {
+                        return mod
+                    }
+                }
+            }
+
+        return null
+    }
+
+    /**
+     *  Returns the module the `PsiElement` belongs to (`self::` in paths). If `elem` is a module, returns `elem`.
+     *
+     *  The module will be in the same file.
+     *
+     *  Reference:
+     *    https://doc.rust-lang.org/reference.html#paths
+     */
+    fun getSelfModFor(elem: PsiElement): RustModItem? {
+        return elem.parentOfType<RustModItem>(strict = false)
     }
 
 }

--- a/test/org/rust/lang/core/resolve/RustMultifileResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustMultifileResolveTestCase.kt
@@ -5,11 +5,11 @@ import org.rust.lang.RustTestCase
 import org.rust.lang.core.resolve.ref.RustReference
 
 
-class RustProjResolveTestCase : RustTestCase() {
+class RustMultiFileResolveTestCase : RustTestCase() {
     override fun getTestDataPath() = "testData/org/rust/lang/core/resolve/fixtures"
 
-    private fun doTest(crateRoot: String, mod: String) {
-        myFixture.configureByFiles(crateRoot, mod)
+    private fun doTest(vararg files: String) {
+        myFixture.configureByFiles(*files)
 
         val usage = file.findReferenceAt(myFixture.caretOffset)!! as RustReference
         val declaration = usage.resolve()
@@ -19,4 +19,6 @@ class RustProjResolveTestCase : RustTestCase() {
 
     fun testChildMod() = doTest("child_mod/main.rs", "child_mod/child.rs")
     fun testNestedChildMod() = doTest("nested_child_mod/main.rs", "nested_child_mod/inner/child.rs")
+    fun testGlobalPath() = doTest("global_path/foo.rs", "global_path/bar.rs", "global_path/lib.rs")
+    fun testUseViewPath() = doTest("global_path/foo.rs", "global_path/bar.rs", "global_path/lib.rs")
 }

--- a/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustResolveTestCase.kt
@@ -1,12 +1,10 @@
 package org.rust.lang.core.resolve
 
-import com.intellij.psi.PsiElement
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RustTestCase
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.resolve.ref.RustReference
 
-class RustResolveTestCase : RustTestCase() {
+class RustResolveTestCase : RustResolveTestCaseBase() {
     override fun getTestDataPath() = "testData/org/rust/lang/core/resolve/fixtures"
 
     fun testFunctionArgument() = checkIsBound()
@@ -34,31 +32,4 @@ class RustResolveTestCase : RustTestCase() {
     fun testModBoundary() = checkIsUnbound()
     fun testFollowPath() = checkIsUnbound()
 
-    private fun assertIsValidDeclaration(declaration: PsiElement, usage: RustReference,
-                                         expectedOffset: Int?) {
-
-        assertThat(declaration).isInstanceOf(RustNamedElement::class.java)
-        declaration as RustNamedElement
-
-
-        if (expectedOffset != null) {
-            assertThat(declaration.textOffset).isEqualTo(expectedOffset)
-        } else {
-            assertThat(declaration.name).isEqualTo(usage.element.name)
-        }
-    }
-
-    private fun checkIsBound(atOffset: Int? = null) {
-        val usage = myFixture.getReferenceAtCaretPosition(fileName) as RustReference
-        val declaration = usage.resolve()!!
-
-        assertIsValidDeclaration(declaration, usage, atOffset)
-    }
-
-    private fun checkIsUnbound() {
-        val usage = myFixture.getReferenceAtCaretPosition(fileName) as RustReference
-        val declaration = usage.resolve()
-
-        assertThat(declaration).isNull()
-    }
 }

--- a/test/org/rust/lang/core/resolve/RustResolveTestCaseBase.kt
+++ b/test/org/rust/lang/core/resolve/RustResolveTestCaseBase.kt
@@ -1,0 +1,37 @@
+package org.rust.lang.core.resolve
+
+import com.intellij.psi.PsiElement
+import org.assertj.core.api.Assertions.assertThat
+import org.rust.lang.RustTestCase
+import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.resolve.ref.RustReference
+
+abstract class RustResolveTestCaseBase : RustTestCase() {
+    private fun assertIsValidDeclaration(declaration: PsiElement, usage: RustReference,
+                                         expectedOffset: Int?) {
+
+        assertThat(declaration).isInstanceOf(RustNamedElement::class.java)
+        declaration as RustNamedElement
+
+
+        if (expectedOffset != null) {
+            assertThat(declaration.textOffset).isEqualTo(expectedOffset)
+        } else {
+            assertThat(declaration.name).isEqualTo(usage.element.name)
+        }
+    }
+
+    final protected fun checkIsBound(atOffset: Int? = null) {
+        val usage = myFixture.getReferenceAtCaretPosition(fileName) as RustReference
+        val declaration = usage.resolve()!!
+
+        assertIsValidDeclaration(declaration, usage, atOffset)
+    }
+
+    final protected fun checkIsUnbound() {
+        val usage = myFixture.getReferenceAtCaretPosition(fileName) as RustReference
+        val declaration = usage.resolve()
+
+        assertThat(declaration).isNull()
+    }
+}

--- a/test/org/rust/lang/core/resolve/RustUseResolveTestCase.kt
+++ b/test/org/rust/lang/core/resolve/RustUseResolveTestCase.kt
@@ -1,0 +1,7 @@
+package org.rust.lang.core.resolve
+
+class RustUseResolveTestCase : RustResolveTestCaseBase() {
+    override fun getTestDataPath() = "testData/org/rust/lang/core/resolve/fixtures/use"
+
+    fun testViewPath() = checkIsBound()
+}

--- a/testData/org/rust/lang/core/resolve/fixtures/global_path/bar.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/global_path/bar.rs
@@ -1,0 +1,3 @@
+pub fn hello() { }
+
+fn second() { }

--- a/testData/org/rust/lang/core/resolve/fixtures/global_path/foo.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/global_path/foo.rs
@@ -1,0 +1,5 @@
+fn main() {
+    ::bar::h<caret>ello();
+}
+
+fn second() { }

--- a/testData/org/rust/lang/core/resolve/fixtures/global_path/lib.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/global_path/lib.rs
@@ -1,0 +1,2 @@
+mod foo;
+pub mod bar;

--- a/testData/org/rust/lang/core/resolve/fixtures/use/view_path.rs
+++ b/testData/org/rust/lang/core/resolve/fixtures/use/view_path.rs
@@ -1,0 +1,7 @@
+mod foo {
+    use ::bar::h<caret>ello;
+}
+
+pub mod bar {
+    pub fn hello() { }
+}


### PR DESCRIPTION
This add resolve for `::foo::bar` paths everywhere and `foo::bar` paths
in `use foo::bar`. It also lays foundation for proper use resolve and
`self::foo`, `super::foo` resolve.

`view_path_part_leftish` is made a distinct subclass of path part. This is necessary to override `isFullyQualified`. The name is way to long for a public PSI node, so I am open for suggestions for a shorter one (`use_path_start` maybe?). The code for determining the crate root and parent module is not strictly correct, but is a good approximation. 

I am also not sure about `getGlobalResolveScopeFor` -> `getCrateRootFor` renaming. I think it is better to stick to Rust specific term in this case. 

@alexeykudinkin @atsky please review